### PR TITLE
Add rviz_plugin_tutorials dependency for ROS1

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -41,6 +41,7 @@
   <!-- ROS1 -->
   <depend           condition="$ROS_VERSION == 1">roscpp</depend>
   <depend           condition="$ROS_VERSION == 1">dynamic_reconfigure</depend>
+  <depend           condition="$ROS_VERSION == 1">rviz_plugin_tutorials</depend>
   <test_depend      condition="$ROS_VERSION == 1">gtest</test_depend>
   
   <!-- ROS2 -->


### PR DESCRIPTION
It's used in the demo RViz configurations. I had to install it manually to make the demos work.

https://index.ros.org/p/rviz_plugin_tutorials/#noetic