### PR TITLE
Fix namespace switching bug between mvsim.chassis_shape and mvsim.chassis_shape.wheel3 in /chassis_markers

### DIFF
--- a/mvsim_node_src/mvsim_node.cpp
+++ b/mvsim_node_src/mvsim_node.cpp
@@ -710,7 +710,7 @@ void MVSimNode::initPubSubs(TPubSubPerVehicle& pubsubs, mvsim::VehicleBase* veh)
 			// Init values. Copy the contents from the chassis msg
 			wheel_shape_msg = msg_shapes.markers[0];
 
-			chassis_shape_msg.ns = mrpt::format(
+			wheel_shape_msg.ns = mrpt::format(
 				"mvsim.chassis_shape.wheel%u", static_cast<unsigned int>(i));
 			wheel_shape_msg.points.resize(5);
 			wheel_shape_msg.points[0].x = lx;


### PR DESCRIPTION
## Summary

This pull request addresses a bug where the namespace (`ns`) was incorrectly switched between `mvsim.chassis_shape` and `mvsim.chassis_shape.wheel3` in the `/chassis_markers` topic. The issue was caused by the `ns` attribute being shared inadvertently among markers during initialization.

## Changes Made

1. **Chassis Marker Initialization**: The `ns` for the chassis marker is set correctly without being modified by the wheel markers.
2. **Wheel Marker Initialization**: Each wheel marker now has its own unique `ns` value set independently, ensuring no unintended changes to the `ns` attribute.

## Details

- The `ns` attribute for each marker is explicitly set after copying the initial values from the chassis marker.
- Ensured that each wheel marker's `ns` is set uniquely using the format `mvsim.chassis_shape.wheelX` where `X` is the wheel index.

## How to Test

1. Run the simulation and observe the `/chassis_markers` topic in RViz or another ROS visualization tool.
2. Verify that the `namespace` for `mvsim.chassis_shape` remains unchanged and each wheel marker (`mvsim.chassis_shape.wheelX`) is set correctly.

This fix should resolve the issue where namespaces were incorrectly shared or modified among different markers, improving the reliability and correctness of marker visualization in the simulation.