### PR TITLE
Support ros1 (tf/tf_static)

### DIFF
--- a/mvsim_node_src/include/mvsim/mvsim_node_core.h
+++ b/mvsim_node_src/include/mvsim/mvsim_node_core.h
@@ -159,6 +159,9 @@ class MVSimNode
 		ros::Publisher pub_collision;  //!< "<VEH>/collision"
 
 		visualization_msgs::MarkerArray chassis_shape_msg;
+
+		ros::Publisher pub_tf;
+		ros::Publisher pub_tf_static;
 #else
 		/// Subscribers vehicle's "cmd_vel" topic
 		rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr sub_cmd_vel;

--- a/mvsim_node_src/mvsim_node.cpp
+++ b/mvsim_node_src/mvsim_node.cpp
@@ -630,6 +630,12 @@ void MVSimNode::initPubSubs(TPubSubPerVehicle& pubsubs, mvsim::VehicleBase* veh)
 	// pub: <VEH>/collision
 	pubsubs.pub_collision = n_.advertise<std_msgs::Bool>(
 		vehVarName("collision", *veh), publisher_history_len_);
+
+	// pub: <VEH>/tf, <VEH>/tf_static
+	pubsubs.pub_tf = n_.advertise<tf2_msgs::TFMessage>(
+		vehVarName("tf", *veh), publisher_history_len_);
+	pubsubs.pub_tf_static = n_.advertise<tf2_msgs::TFMessage>(
+		vehVarName("tf_static", *veh), publisher_history_len_);
 #else
 	// pub: <VEH>/odom
 	pubsubs.pub_odom = n_->create_publisher<nav_msgs::msg::Odometry>(
@@ -821,9 +827,15 @@ void MVSimNode::initPubSubs(TPubSubPerVehicle& pubsubs, mvsim::VehicleBase* veh)
 	tx.header.stamp = myNow();
 	tx.transform = tf2::toMsg(tfIdentity_);
 
+#if PACKAGE_ROS_VERSION == 1
+	tf2_msgs::TFMessage tfMsg;
+	tfMsg.transforms.push_back(tx);
+	pubsubs.pub_tf_static.publish(tfMsg);
+#else
 	tf2_msgs::msg::TFMessage tfMsg;
 	tfMsg.transforms.push_back(tx);
 	pubsubs.pub_tf_static->publish(tfMsg);
+#endif
 }
 
 void MVSimNode::onROSMsgCmdVel(
@@ -986,10 +998,17 @@ void MVSimNode::spinNotifyROS()
 						tf_br_.sendTransform(tx);
 
 						// TF: <Ri>/map -> <Ri>/odom
+#if PACKAGE_ROS_VERSION == 1
+						tf2_msgs::TFMessage tfMsg;
+						tx.header.frame_id = vehVarName("map", *veh);
+						tfMsg.transforms.push_back(tx);
+						pubs.pub_tf.publish(tfMsg);
+#else
 						tf2_msgs::msg::TFMessage tfMsg;
 						tx.header.frame_id = vehVarName("map", *veh);
 						tfMsg.transforms.push_back(tx);
 						pubs.pub_tf->publish(tfMsg);
+#endif
 					}
 				}
 			}
@@ -1038,9 +1057,15 @@ void MVSimNode::spinNotifyROS()
 						tf2::toMsg(mrpt2ros::toROS_tfTransform(odo_pose));
 					tf_br_.sendTransform(tx);
 
+#if PACKAGE_ROS_VERSION == 1
+					tf2_msgs::TFMessage tfMsg;
+					tfMsg.transforms.push_back(tx);
+					pubs.pub_tf.publish(tfMsg);
+#else
 					tf2_msgs::msg::TFMessage tfMsg;
 					tfMsg.transforms.push_back(tx);
 					pubs.pub_tf->publish(tfMsg);
+#endif
 				}
 
 				// Apart from TF, publish to the "odom" topic as well
@@ -1230,9 +1255,15 @@ void MVSimNode::internalOn(
 	tfStmp.header.stamp = myNow();
 	tf_br_.sendTransform(tfStmp);
 
+#if PACKAGE_ROS_VERSION == 1
+	tf2_msgs::TFMessage tfMsg;
+	tfMsg.transforms.push_back(tfStmp);
+	pubs.pub_tf.publish(tfMsg);
+#else
 	tf2_msgs::msg::TFMessage tfMsg;
 	tfMsg.transforms.push_back(tfStmp);
 	pubs.pub_tf->publish(tfMsg);
+#endif
 
 	// Send observation:
 	{
@@ -1304,9 +1335,15 @@ void MVSimNode::internalOn(
 	tfStmp.header.stamp = myNow();
 	tf_br_.sendTransform(tfStmp);
 
+#if PACKAGE_ROS_VERSION == 1
+	tf2_msgs::TFMessage tfMsg;
+	tfMsg.transforms.push_back(tfStmp);
+	pubs.pub_tf.publish(tfMsg);
+#else
 	tf2_msgs::msg::TFMessage tfMsg;
 	tfMsg.transforms.push_back(tfStmp);
 	pubs.pub_tf->publish(tfMsg);
+#endif
 
 	// Send observation:
 	{
@@ -1378,9 +1415,15 @@ void MVSimNode::internalOn(
 	tfStmp.header.stamp = myNow();
 	tf_br_.sendTransform(tfStmp);
 
+#if PACKAGE_ROS_VERSION == 1
+	tf2_msgs::TFMessage tfMsg;
+	tfMsg.transforms.push_back(tfStmp);
+	pubs.pub_tf.publish(tfMsg);
+#else
 	tf2_msgs::msg::TFMessage tfMsg;
 	tfMsg.transforms.push_back(tfStmp);
 	pubs.pub_tf->publish(tfMsg);
+#endif
 
 	// Send observation:
 	{
@@ -1474,9 +1517,15 @@ void MVSimNode::internalOn(
 		tfStmp.header.stamp = now;
 		tf_br_.sendTransform(tfStmp);
 
+#if PACKAGE_ROS_VERSION == 1
+		tf2_msgs::TFMessage tfMsg;
+		tfMsg.transforms.push_back(tfStmp);
+		pubs.pub_tf.publish(tfMsg);
+#else
 		tf2_msgs::msg::TFMessage tfMsg;
 		tfMsg.transforms.push_back(tfStmp);
 		pubs.pub_tf->publish(tfMsg);
+#endif
 
 		// Send observation:
 		{
@@ -1517,9 +1566,15 @@ void MVSimNode::internalOn(
 		tfStmp.header.stamp = now;
 		tf_br_.sendTransform(tfStmp);
 
+#if PACKAGE_ROS_VERSION == 1
+		tf2_msgs::TFMessage tfMsg;
+		tfMsg.transforms.push_back(tfStmp);
+		pubs.pub_tf.publish(tfMsg);
+#else
 		tf2_msgs::msg::TFMessage tfMsg;
 		tfMsg.transforms.push_back(tfStmp);
 		pubs.pub_tf->publish(tfMsg);
+#endif
 
 		// Send observation:
 		{
@@ -1606,9 +1661,15 @@ void MVSimNode::internalOn(
 	tfStmp.header.stamp = now;
 	tf_br_.sendTransform(tfStmp);
 
+#if PACKAGE_ROS_VERSION == 1
+	tf2_msgs::TFMessage tfMsg;
+	tfMsg.transforms.push_back(tfStmp);
+	pubs.pub_tf.publish(tfMsg);
+#else
 	tf2_msgs::msg::TFMessage tfMsg;
 	tfMsg.transforms.push_back(tfStmp);
 	pubs.pub_tf->publish(tfMsg);
+#endif
 
 	// Send observation:
 	{

--- a/mvsim_node_src/mvsim_node.cpp
+++ b/mvsim_node_src/mvsim_node.cpp
@@ -827,6 +827,9 @@ void MVSimNode::initPubSubs(TPubSubPerVehicle& pubsubs, mvsim::VehicleBase* veh)
 	tx.header.stamp = myNow();
 	tx.transform = tf2::toMsg(tfIdentity_);
 
+	// TF STATIC(namespace <Ri>): /base_link -> /base_footprint
+	tx.header.frame_id = "base_link";
+	tx.child_frame_id = "base_footprint";
 #if PACKAGE_ROS_VERSION == 1
 	tf2_msgs::TFMessage tfMsg;
 	tfMsg.transforms.push_back(tx);
@@ -997,15 +1000,14 @@ void MVSimNode::spinNotifyROS()
 							tf2::toMsg(tf2::Transform::getIdentity());
 						tf_br_.sendTransform(tx);
 
-						// TF: <Ri>/map -> <Ri>/odom
+						// TF(namespace <Ri>): /map -> /odom
+						tx.child_frame_id = "odom";
 #if PACKAGE_ROS_VERSION == 1
 						tf2_msgs::TFMessage tfMsg;
-						tx.header.frame_id = vehVarName("map", *veh);
 						tfMsg.transforms.push_back(tx);
 						pubs.pub_tf.publish(tfMsg);
 #else
 						tf2_msgs::msg::TFMessage tfMsg;
-						tx.header.frame_id = vehVarName("map", *veh);
 						tfMsg.transforms.push_back(tx);
 						pubs.pub_tf->publish(tfMsg);
 #endif
@@ -1057,6 +1059,9 @@ void MVSimNode::spinNotifyROS()
 						tf2::toMsg(mrpt2ros::toROS_tfTransform(odo_pose));
 					tf_br_.sendTransform(tx);
 
+					// TF(namespace <Ri>): /odom -> /base_link
+					tx.header.frame_id = "odom";
+					tx.child_frame_id = "base_link";
 #if PACKAGE_ROS_VERSION == 1
 					tf2_msgs::TFMessage tfMsg;
 					tfMsg.transforms.push_back(tx);
@@ -1250,11 +1255,13 @@ void MVSimNode::internalOn(
 
 	Msg_TransformStamped tfStmp;
 	tfStmp.transform = tf2::toMsg(transform);
-	tfStmp.child_frame_id = sSensorFrameId;
 	tfStmp.header.frame_id = vehVarName("base_link", veh);
+	tfStmp.child_frame_id = sSensorFrameId;
 	tfStmp.header.stamp = myNow();
 	tf_br_.sendTransform(tfStmp);
 
+	tfStmp.header.frame_id = "base_link";
+	tfStmp.child_frame_id = obs.sensorLabel;
 #if PACKAGE_ROS_VERSION == 1
 	tf2_msgs::TFMessage tfMsg;
 	tfMsg.transforms.push_back(tfStmp);
@@ -1330,11 +1337,13 @@ void MVSimNode::internalOn(
 
 	Msg_TransformStamped tfStmp;
 	tfStmp.transform = tf2::toMsg(transform);
-	tfStmp.child_frame_id = sSensorFrameId;
 	tfStmp.header.frame_id = vehVarName("base_link", veh);
+	tfStmp.child_frame_id = sSensorFrameId;
 	tfStmp.header.stamp = myNow();
 	tf_br_.sendTransform(tfStmp);
 
+	tfStmp.header.frame_id = "base_link";
+	tfStmp.child_frame_id = obs.sensorLabel;
 #if PACKAGE_ROS_VERSION == 1
 	tf2_msgs::TFMessage tfMsg;
 	tfMsg.transforms.push_back(tfStmp);
@@ -1410,11 +1419,13 @@ void MVSimNode::internalOn(
 
 	Msg_TransformStamped tfStmp;
 	tfStmp.transform = tf2::toMsg(transform);
-	tfStmp.child_frame_id = sSensorFrameId;
 	tfStmp.header.frame_id = vehVarName("base_link", veh);
+	tfStmp.child_frame_id = sSensorFrameId;
 	tfStmp.header.stamp = myNow();
 	tf_br_.sendTransform(tfStmp);
 
+	tfStmp.header.frame_id = "base_link";
+	tfStmp.child_frame_id = obs.sensorLabel;
 #if PACKAGE_ROS_VERSION == 1
 	tf2_msgs::TFMessage tfMsg;
 	tfMsg.transforms.push_back(tfStmp);
@@ -1512,11 +1523,13 @@ void MVSimNode::internalOn(
 
 		Msg_TransformStamped tfStmp;
 		tfStmp.transform = tf2::toMsg(transform);
-		tfStmp.child_frame_id = sSensorFrameId_image;
 		tfStmp.header.frame_id = vehVarName("base_link", veh);
+		tfStmp.child_frame_id = sSensorFrameId_image;
 		tfStmp.header.stamp = now;
 		tf_br_.sendTransform(tfStmp);
 
+		tfStmp.header.frame_id = "base_link";
+		tfStmp.child_frame_id = lbImage;
 #if PACKAGE_ROS_VERSION == 1
 		tf2_msgs::TFMessage tfMsg;
 		tfMsg.transforms.push_back(tfStmp);
@@ -1561,11 +1574,13 @@ void MVSimNode::internalOn(
 
 		Msg_TransformStamped tfStmp;
 		tfStmp.transform = tf2::toMsg(transform);
-		tfStmp.child_frame_id = sSensorFrameId_points;
 		tfStmp.header.frame_id = vehVarName("base_link", veh);
+		tfStmp.child_frame_id = sSensorFrameId_points;
 		tfStmp.header.stamp = now;
 		tf_br_.sendTransform(tfStmp);
 
+		tfStmp.header.frame_id = "base_link";
+		tfStmp.child_frame_id = lbPoints;
 #if PACKAGE_ROS_VERSION == 1
 		tf2_msgs::TFMessage tfMsg;
 		tfMsg.transforms.push_back(tfStmp);
@@ -1656,11 +1671,13 @@ void MVSimNode::internalOn(
 
 	Msg_TransformStamped tfStmp;
 	tfStmp.transform = tf2::toMsg(transform);
-	tfStmp.child_frame_id = sSensorFrameId_points;
 	tfStmp.header.frame_id = vehVarName("base_link", veh);
+	tfStmp.child_frame_id = sSensorFrameId_points;
 	tfStmp.header.stamp = now;
 	tf_br_.sendTransform(tfStmp);
 
+	tfStmp.header.frame_id = "base_link";
+	tfStmp.child_frame_id = lbPoints;
 #if PACKAGE_ROS_VERSION == 1
 	tf2_msgs::TFMessage tfMsg;
 	tfMsg.transforms.push_back(tfStmp);


### PR DESCRIPTION
### Commits

- ros1 support

    - I updated to support ros1.
    - I tested on Ubuntu 20.04(noetic) and Ubuntu 22.04(humble).

- Same fame id(each namespace)

    - Nav2's policy is to keep frame id and control only by topic name(namespace). [related PR](https://github.com/ros-navigation/navigation2/pull/4594)
    - So I changed frame id of each topic to be the same. (It only applies to /\<Ri\>/tf)