### PR TITLE
Fix fake amcl topic (QoS Durability)

### DIFF
--- a/mvsim_node_src/mvsim_node.cpp
+++ b/mvsim_node_src/mvsim_node.cpp
@@ -733,15 +733,20 @@ void MVSimNode::initPubSubs(TPubSubPerVehicle& pubsubs, mvsim::VehicleBase* veh)
 	{
 #if PACKAGE_ROS_VERSION == 1
 		// pub: <VEH>/amcl_pose
-		pubsubs.pub_amcl_pose = mvsim_node::make_shared<ros::Publisher>(
-			n_.advertise<Msg_PoseWithCovarianceStamped>(vehVarName("amcl_pose", *veh), 1));
+		pubsubs.pub_amcl_pose =
+			mvsim_node::make_shared<ros::Publisher>(n_.advertise<Msg_PoseWithCovarianceStamped>(
+				vehVarName("amcl_pose", *veh), 1, true /*latch*/));
 		// pub: <VEH>/particlecloud
 		pubsubs.pub_particlecloud = mvsim_node::make_shared<ros::Publisher>(
 			n_.advertise<Msg_PoseArray>(vehVarName("particlecloud", *veh), 1));
 #else
+		rclcpp::QoS qosLatched1(rclcpp::KeepLast(1));
+		qosLatched1.durability(
+			rmw_qos_durability_policy_t::RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
+
 		// pub: <VEH>/amcl_pose
-		pubsubs.pub_amcl_pose =
-			n_->create_publisher<Msg_PoseWithCovarianceStamped>(vehVarName("amcl_pose", *veh), 1);
+		pubsubs.pub_amcl_pose = n_->create_publisher<Msg_PoseWithCovarianceStamped>(
+			vehVarName("amcl_pose", *veh), qosLatched1);
 		// pub: <VEH>/particlecloud
 		pubsubs.pub_particlecloud =
 			n_->create_publisher<Msg_PoseArray>(vehVarName("particlecloud", *veh), 1);


### PR DESCRIPTION
QoS Durability of amcl_pose topic should be TRANSIENT_LOCAL for nav2 compatibility.

So I changed the durability from volatile to transient_local.

> ros2 topic info /amcl_pose -v

- before
```bash
Node name: mvsim
Node namespace: /
Topic type: geometry_msgs/msg/PoseWithCovarianceStamped
Endpoint type: PUBLISHER
GID: 01.0f.00.01.ea.10.be.36.00.00.00.00.00.00.1d.03.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RELIABLE
  History (Depth): UNKNOWN
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite
```

- after
```bash
Node name: mvsim
Node namespace: /
Topic type: geometry_msgs/msg/PoseWithCovarianceStamped
Endpoint type: PUBLISHER
GID: 01.0f.00.01.b7.1a.6c.9f.00.00.00.00.00.00.1d.03.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RELIABLE
  History (Depth): UNKNOWN
  Durability: TRANSIENT_LOCAL
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite
```