### PR TITLE
Fix/python service call encoding

### DIFF
--- a/cmake/mvsim_cmake_functions.cmake
+++ b/cmake/mvsim_cmake_functions.cmake
@@ -72,7 +72,7 @@ function(mvsim_add_test)
 
     # Run it:
     add_custom_target(run_${mvsim_add_test_TARGET} COMMAND $<TARGET_FILE:${mvsim_add_test_TARGET}>)
-    add_test(${mvsim_add_test_TARGET}_build "${CMAKE_COMMAND}" --build ${CMAKE_CURRENT_BINARY_DIR} --target ${mvsim_add_test_TARGET})
+    add_test(${mvsim_add_test_TARGET}_build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target ${mvsim_add_test_TARGET})
     add_test(run_${mvsim_add_test_TARGET} ${EXECUTABLE_OUTPUT_PATH}/${mvsim_add_test_TARGET})
     set_tests_properties(run_${mvsim_add_test_TARGET} PROPERTIES DEPENDS ${mvsim_add_test_TARGET}_build)
 

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -157,9 +157,9 @@ function(mvsim_common_target_settings MODULENAME_)
     target_compile_definitions(${TARGETNAME_} PUBLIC MVSIM_HAS_ZMQ)
   endif()
 
-	if (MVSIM_WITH_PYTHON)
-		target_compile_definitions(${TARGETNAME_} PUBLIC MVSIM_HAS_PYTHON)
-	endif()
+  if (MVSIM_WITH_PYTHON)
+    target_compile_definitions(${TARGETNAME_} PUBLIC MVSIM_HAS_PYTHON)
+  endif()
 
   # ==== Install & export target ========
   install(TARGETS	${TARGETNAME_}

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -157,6 +157,10 @@ function(mvsim_common_target_settings MODULENAME_)
     target_compile_definitions(${TARGETNAME_} PUBLIC MVSIM_HAS_ZMQ)
   endif()
 
+	if (MVSIM_WITH_PYTHON)
+		target_compile_definitions(${TARGETNAME_} PUBLIC MVSIM_HAS_PYTHON)
+	endif()
+
   # ==== Install & export target ========
   install(TARGETS	${TARGETNAME_}
 		  EXPORT 	${TARGETNAME_}-targets

--- a/modules/comms/CMakeLists.txt
+++ b/modules/comms/CMakeLists.txt
@@ -32,7 +32,6 @@ target_link_libraries(${PROJECT_NAME}
 	mrpt::io
 	mrpt::serialization
 	mvsim::msgs
-	pybind11::module
 )
 
 # =========== Python wrapper ==================
@@ -46,6 +45,12 @@ if (MVSIM_WITH_PYTHON)
   if ($ENV{VERBOSE})
     message(STATUS "PYBIND11_VERSION         : ${PYBIND11_MAJOR_VERSION}.${PYBIND11_MINOR_VERSION}.${PYBIND11_PATCH_VERSION}")
   endif()
+
+	target_link_libraries(${PROJECT_NAME}
+		PUBLIC
+		pybind11::module
+		Python3::Python
+	)
 
   set(PY_SRCS_DIR ${CMAKE_CURRENT_LIST_DIR}/python/generated-sources-pybind)
 

--- a/modules/comms/CMakeLists.txt
+++ b/modules/comms/CMakeLists.txt
@@ -46,11 +46,11 @@ if (MVSIM_WITH_PYTHON)
     message(STATUS "PYBIND11_VERSION         : ${PYBIND11_MAJOR_VERSION}.${PYBIND11_MINOR_VERSION}.${PYBIND11_PATCH_VERSION}")
   endif()
 
-	target_link_libraries(${PROJECT_NAME}
-		PUBLIC
-		pybind11::module
-		Python3::Python
-	)
+  target_link_libraries(${PROJECT_NAME}
+   PUBLIC
+    pybind11::module
+    Python3::Python
+  )
 
   set(PY_SRCS_DIR ${CMAKE_CURRENT_LIST_DIR}/python/generated-sources-pybind)
 

--- a/modules/comms/CMakeLists.txt
+++ b/modules/comms/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(${PROJECT_NAME}
 	mrpt::io
 	mrpt::serialization
 	mvsim::msgs
+	pybind11::module
 )
 
 # =========== Python wrapper ==================

--- a/modules/comms/include/mvsim/Comms/Client.h
+++ b/modules/comms/include/mvsim/Comms/Client.h
@@ -14,6 +14,12 @@
 #include <mvsim/Comms/common.h>
 #include <mvsim/Comms/zmq_fwrds.h>
 
+#if defined(MVSIM_HAS_PYTHON)
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+#endif
+
 #include <atomic>
 #include <memory>
 #include <thread>
@@ -96,8 +102,10 @@ class Client : public mrpt::system::COutputLogger
 	void callService(
 		const std::string& serviceName, const INPUT_MSG_T& input, OUTPUT_MSG_T& output);
 
+	#if defined(MVSIM_HAS_PYTHON)
 	/// Overload for python wrapper
-	std::string callService(const std::string& serviceName, const std::string& inputSerializedMsg);
+	py::bytes callService(const std::string& serviceName, const std::string& inputSerializedMsg);
+	#endif
 
 	/// Overload for python wrapper (callback accepts bytes-string)
 	void subscribeTopic(

--- a/modules/comms/include/mvsim/Comms/Client.h
+++ b/modules/comms/include/mvsim/Comms/Client.h
@@ -12,6 +12,7 @@
 #include <mrpt/system/COutputLogger.h>
 #include <mrpt/system/CTimeLogger.h>
 #include <mvsim/Comms/common.h>
+#include <mvsim/Comms/visibility.h>
 #include <mvsim/Comms/zmq_fwrds.h>
 
 #if defined(MVSIM_HAS_PYTHON)
@@ -51,7 +52,7 @@ namespace mvsim
  *
  * \ingroup mvsim_comms_module
  */
-class Client : public mrpt::system::COutputLogger
+class MVSIM_PUBLIC Client : public mrpt::system::COutputLogger
 {
    public:
 	Client();

--- a/modules/comms/include/mvsim/Comms/Client.h
+++ b/modules/comms/include/mvsim/Comms/Client.h
@@ -102,10 +102,10 @@ class Client : public mrpt::system::COutputLogger
 	void callService(
 		const std::string& serviceName, const INPUT_MSG_T& input, OUTPUT_MSG_T& output);
 
-	#if defined(MVSIM_HAS_PYTHON)
+#if defined(MVSIM_HAS_PYTHON)
 	/// Overload for python wrapper
 	py::bytes callService(const std::string& serviceName, const std::string& inputSerializedMsg);
-	#endif
+#endif
 
 	/// Overload for python wrapper (callback accepts bytes-string)
 	void subscribeTopic(

--- a/modules/comms/include/mvsim/Comms/Server.h
+++ b/modules/comms/include/mvsim/Comms/Server.h
@@ -12,6 +12,7 @@
 #include <mrpt/core/Clock.h>
 #include <mrpt/system/COutputLogger.h>
 #include <mvsim/Comms/ports.h>
+#include <mvsim/Comms/visibility.h>
 #include <mvsim/Comms/zmq_fwrds.h>
 
 #include <atomic>
@@ -57,7 +58,7 @@ class World;
  *
  * See: https://mvsimulator.readthedocs.io/
  */
-class Server : public mrpt::system::COutputLogger
+class MVSIM_PUBLIC Server : public mrpt::system::COutputLogger
 {
    public:
 	Server();

--- a/modules/comms/include/mvsim/Comms/visibility.h
+++ b/modules/comms/include/mvsim/Comms/visibility.h
@@ -1,0 +1,30 @@
+#pragma once
+
+// From https://gcc.gnu.org/wiki/Visibility
+#if defined(_WIN32) || defined(__CYGWIN__)
+// Assume we are always building a library for now to simplify
+// #ifdef MVSIM_BUILDING_LIBRARY
+#if defined(__GNUC__) || defined(__clang__)
+#define MVSIM_PUBLIC __attribute__((dllexport))
+#else
+#define MVSIM_PUBLIC \
+	__declspec(dllexport)  // Note: actually gcc seems to also supports this syntax.
+#endif
+// #else
+//   #if defined(__GNUC__) || defined(__clang__)
+//     #define MVSIM_PUBLIC __attribute__ ((dllimport))
+//   #else
+//     #define MVSIM_PUBLIC __declspec(dllimport) // Note: actually gcc seems to also supports this
+//     syntax.
+//   #endif
+// #endif
+#define MVSIM_LOCAL
+#else
+#if __GNUC__ >= 4 || defined(__clang__)
+#define MVSIM_PUBLIC __attribute__((visibility("default")))
+#define MVSIM_LOCAL __attribute__((visibility("hidden")))
+#else
+#define MVSIM_PUBLIC
+#define MVSIM_LOCAL
+#endif
+#endif

--- a/modules/comms/python/generated-sources-pybind/mvsim/Comms/Client.cpp
+++ b/modules/comms/python/generated-sources-pybind/mvsim/Comms/Client.cpp
@@ -1,5 +1,6 @@
 #include <mrpt/system/CTimeLogger.h>
 #include <mvsim/Comms/Client.h>
+#include <pybind11/functional.h>  // This is added to the generated output
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -79,15 +80,15 @@ void bind_mvsim_Comms_Client(std::function<pybind11::module&(std::string const& 
 			"mvsim::Client::subscribeTopic(const std::string &, const class std::function<void "
 			"(const std::string &, const class std::vector<unsigned char> &)> &) --> void",
 			pybind11::arg("topicName"), pybind11::arg("callback"));
-		cl.def(
-			"subscribe_topic_raw",
-			(void(mvsim::Client::*)(
-				const std::string&,
-				const class std::function<void(const class zmq::message_t&)>&)) &
-				mvsim::Client::subscribe_topic_raw,
-			"C++: mvsim::Client::subscribe_topic_raw(const std::string &, const class "
-			"std::function<void (const class zmq::message_t &)> &) --> void",
-			pybind11::arg("topicName"), pybind11::arg("callback"));
+		// cl.def(
+		// 	"subscribe_topic_raw",
+		// 	(void(mvsim::Client::*)(
+		// 		const std::string&,
+		// 		const class std::function<void(const class zmq::message_t&)>&)) &
+		// 		mvsim::Client::subscribe_topic_raw,
+		// 	"C++: mvsim::Client::subscribe_topic_raw(const std::string &, const class "
+		// 	"std::function<void (const class zmq::message_t &)> &) --> void",
+		// 	pybind11::arg("topicName"), pybind11::arg("callback"));
 		cl.def(
 			"enable_profiler", (void(mvsim::Client::*)(bool)) & mvsim::Client::enable_profiler,
 			"C++: mvsim::Client::enable_profiler(bool) --> void", pybind11::arg("enable"));

--- a/modules/comms/python/generated-sources-pybind/mvsim/Comms/Client.cpp
+++ b/modules/comms/python/generated-sources-pybind/mvsim/Comms/Client.cpp
@@ -1,6 +1,5 @@
 #include <mrpt/system/CTimeLogger.h>
 #include <mvsim/Comms/Client.h>
-#include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -13,27 +12,24 @@
 
 #ifndef BINDER_PYBIND11_TYPE_CASTER
 #define BINDER_PYBIND11_TYPE_CASTER
-PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)
-PYBIND11_DECLARE_HOLDER_TYPE(T, T*)
+PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>, false)
+PYBIND11_DECLARE_HOLDER_TYPE(T, T*, false)
 PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>)
 #endif
 
 void bind_mvsim_Comms_Client(std::function<pybind11::module&(std::string const& namespace_)>& M)
 {
-	{  // mvsim::Client file:mvsim/Comms/Client.h line:48
+	{  // mvsim::Client file:mvsim/Comms/Client.h line:54
 		pybind11::class_<mvsim::Client, std::shared_ptr<mvsim::Client>> cl(
 			M("mvsim"), "Client",
-			"This is the connection of any user program with the MVSIM server, "
-			"so\n it can advertise and subscribe to topics and use remote "
-			"services.\n\n Users should instance a class mvsim::Client (C++) "
-			"or mvsim.Client (Python) to\n communicate with the simulation "
-			"runnin in mvsim::World or any other module.\n\n Usage:\n  - "
-			"Instantiate a Client object.\n  - Call connect(). It will return "
-			"immediately.\n  - The client will be working on the background as "
-			"long as the object is not\n destroyed.\n\n Messages and topics "
-			"are described as Protobuf messages, and communications\n are done "
-			"via ZMQ sockets.\n\n See: https://mvsimulator.readthedocs.io/\n\n "
-			"\n\n ");
+			"This is the connection of any user program with the MVSIM server, so\n it can "
+			"advertise and subscribe to topics and use remote services.\n\n Users should instance "
+			"a class mvsim::Client (C++) or mvsim.Client (Python) to\n communicate with the "
+			"simulation runnin in mvsim::World or any other module.\n\n Usage:\n  - Instantiate a "
+			"Client object.\n  - Call connect(). It will return immediately.\n  - The client will "
+			"be working on the background as long as the object is not\n destroyed.\n\n Messages "
+			"and topics are described as Protobuf messages, and communications\n are done via ZMQ "
+			"sockets.\n\n See: https://mvsimulator.readthedocs.io/\n\n \n\n ");
 		cl.def(pybind11::init([]() { return new mvsim::Client(); }));
 		cl.def(pybind11::init<const std::string&>(), pybind11::arg("nodeName"));
 
@@ -44,58 +40,59 @@ void bind_mvsim_Comms_Client(std::function<pybind11::module&(std::string const& 
 		cl.def(
 			"serverHostAddress",
 			(const std::string& (mvsim::Client::*)() const) & mvsim::Client::serverHostAddress,
-			"C++: mvsim::Client::serverHostAddress() const --> const "
-			"std::string &",
+			"C++: mvsim::Client::serverHostAddress() const --> const std::string &",
 			pybind11::return_value_policy::automatic);
 		cl.def(
 			"serverHostAddress",
 			(void(mvsim::Client::*)(const std::string&)) & mvsim::Client::serverHostAddress,
-			"C++: mvsim::Client::serverHostAddress(const std::string &) --> "
-			"void",
+			"C++: mvsim::Client::serverHostAddress(const std::string &) --> void",
 			pybind11::arg("serverIpOrAddressName"));
 		cl.def(
 			"connect", (void(mvsim::Client::*)()) & mvsim::Client::connect,
-			"Connects to the server in a parallel thread.\n  Default server "
-			"address is `localhost`, can be changed with\n "
-			"serverHostAddress().\n\nC++: mvsim::Client::connect() --> void");
+			"Connects to the server in a parallel thread.\n  Default server address is "
+			"`localhost`, can be changed with\n serverHostAddress().\n\nC++: "
+			"mvsim::Client::connect() --> void");
 		cl.def(
 			"connected", (bool(mvsim::Client::*)() const) & mvsim::Client::connected,
 			"Whether the client is correctly connected to the server. \n\nC++: "
 			"mvsim::Client::connected() const --> bool");
 		cl.def(
 			"shutdown", (void(mvsim::Client::*)()) & mvsim::Client::shutdown,
-			"Shutdowns the communication thread. Blocks until the thread is "
-			"stopped.\n There is no need to manually call this method, it is "
-			"called upon\n destruction. \n\nC++: mvsim::Client::shutdown() --> "
-			"void");
+			"Shutdowns the communication thread. Blocks until the thread is stopped.\n There is no "
+			"need to manually call this method, it is called upon\n destruction. \n\nC++: "
+			"mvsim::Client::shutdown() --> void");
 		cl.def(
 			"callService",
-			(std::string(mvsim::Client::*)(const std::string&, const std::string&)) &
+			(class pybind11::bytes(mvsim::Client::*)(const std::string&, const std::string&)) &
 				mvsim::Client::callService,
-			"Overload for python wrapper\n\nC++: "
-			"mvsim::Client::callService(const std::string &, const std::string "
-			"&) --> std::string",
+			"Overload for python wrapper\n\nC++: mvsim::Client::callService(const std::string &, "
+			"const std::string &) --> class pybind11::bytes",
 			pybind11::arg("serviceName"), pybind11::arg("inputSerializedMsg"));
 		cl.def(
 			"subscribeTopic",
 			(void(mvsim::Client::*)(
 				const std::string&,
 				const class std::function<void(
-					const std::string&,
-					const class std::vector<
-						unsigned char, class std::allocator<unsigned char>>&)>&)) &
+					const std::string&, const class std::vector<unsigned char>&)>&)) &
 				mvsim::Client::subscribeTopic,
-			"Overload for python wrapper (callback accepts "
-			"bytes-string)\n\nC++: mvsim::Client::subscribeTopic(const "
-			"std::string &, const class std::function<void (const std::string "
-			"&, const class std::vector<unsigned char, class "
-			"std::allocator<unsigned char> > &)> &) --> void",
+			"Overload for python wrapper (callback accepts bytes-string)\n\nC++: "
+			"mvsim::Client::subscribeTopic(const std::string &, const class std::function<void "
+			"(const std::string &, const class std::vector<unsigned char> &)> &) --> void",
+			pybind11::arg("topicName"), pybind11::arg("callback"));
+		cl.def(
+			"subscribe_topic_raw",
+			(void(mvsim::Client::*)(
+				const std::string&,
+				const class std::function<void(const class zmq::message_t&)>&)) &
+				mvsim::Client::subscribe_topic_raw,
+			"C++: mvsim::Client::subscribe_topic_raw(const std::string &, const class "
+			"std::function<void (const class zmq::message_t &)> &) --> void",
 			pybind11::arg("topicName"), pybind11::arg("callback"));
 		cl.def(
 			"enable_profiler", (void(mvsim::Client::*)(bool)) & mvsim::Client::enable_profiler,
 			"C++: mvsim::Client::enable_profiler(bool) --> void", pybind11::arg("enable"));
 
-		{  // mvsim::Client::InfoPerNode file:mvsim/Comms/Client.h line:113
+		{  // mvsim::Client::InfoPerNode file:mvsim/Comms/Client.h line:117
 			auto& enclosing_class = cl;
 			pybind11::class_<
 				mvsim::Client::InfoPerNode, std::shared_ptr<mvsim::Client::InfoPerNode>>
@@ -110,12 +107,11 @@ void bind_mvsim_Comms_Client(std::function<pybind11::module&(std::string const& 
 				 (mvsim::Client::InfoPerNode::*)(const struct mvsim::Client::InfoPerNode&)) &
 					mvsim::Client::InfoPerNode::operator=,
 				"C++: mvsim::Client::InfoPerNode::operator=(const struct "
-				"mvsim::Client::InfoPerNode &) --> struct "
-				"mvsim::Client::InfoPerNode &",
+				"mvsim::Client::InfoPerNode &) --> struct mvsim::Client::InfoPerNode &",
 				pybind11::return_value_policy::automatic, pybind11::arg(""));
 		}
 
-		{  // mvsim::Client::InfoPerTopic file:mvsim/Comms/Client.h line:119
+		{  // mvsim::Client::InfoPerTopic file:mvsim/Comms/Client.h line:123
 			auto& enclosing_class = cl;
 			pybind11::class_<
 				mvsim::Client::InfoPerTopic, std::shared_ptr<mvsim::Client::InfoPerTopic>>
@@ -133,8 +129,7 @@ void bind_mvsim_Comms_Client(std::function<pybind11::module&(std::string const& 
 				 (mvsim::Client::InfoPerTopic::*)(const struct mvsim::Client::InfoPerTopic&)) &
 					mvsim::Client::InfoPerTopic::operator=,
 				"C++: mvsim::Client::InfoPerTopic::operator=(const struct "
-				"mvsim::Client::InfoPerTopic &) --> struct "
-				"mvsim::Client::InfoPerTopic &",
+				"mvsim::Client::InfoPerTopic &) --> struct mvsim::Client::InfoPerTopic &",
 				pybind11::return_value_policy::automatic, pybind11::arg(""));
 		}
 	}

--- a/modules/comms/python/generated-sources-pybind/mvsim/Comms/common.cpp
+++ b/modules/comms/python/generated-sources-pybind/mvsim/Comms/common.cpp
@@ -9,12 +9,12 @@
 
 #ifndef BINDER_PYBIND11_TYPE_CASTER
 #define BINDER_PYBIND11_TYPE_CASTER
-PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)
-PYBIND11_DECLARE_HOLDER_TYPE(T, T*)
+PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>, false)
+PYBIND11_DECLARE_HOLDER_TYPE(T, T*, false)
 PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>)
 #endif
 
-// mvsim::UnexpectedMessageException file:mvsim/Comms/common.h line:49
+// mvsim::UnexpectedMessageException file:mvsim/Comms/common.h line:51
 struct PyCallBack_mvsim_UnexpectedMessageException : public mvsim::UnexpectedMessageException
 {
 	using mvsim::UnexpectedMessageException::UnexpectedMessageException;
@@ -29,16 +29,10 @@ struct PyCallBack_mvsim_UnexpectedMessageException : public mvsim::UnexpectedMes
 			auto o = overload.operator()<pybind11::return_value_policy::reference>();
 			if (pybind11::detail::cast_is_temporary_value_reference<const char*>::value)
 			{
-// pybind11 <=2.4: overload_caster_t, otherwise: override_caster_t
-#if (PYBIND11_MAJOR_VERSION == 2 && PYBIND11_MINOR_VERSION <= 4)
-				static pybind11::detail::overload_caster_t<const char*> caster;
-#else
 				static pybind11::detail::override_caster_t<const char*> caster;
-#endif
 				return pybind11::detail::cast_ref<const char*>(std::move(o), caster);
 			}
-			else
-				return pybind11::detail::cast_safe<const char*>(std::move(o));
+			return pybind11::detail::cast_safe<const char*>(std::move(o));
 		}
 		return runtime_error::what();
 	}
@@ -46,7 +40,7 @@ struct PyCallBack_mvsim_UnexpectedMessageException : public mvsim::UnexpectedMes
 
 void bind_mvsim_Comms_common(std::function<pybind11::module&(std::string const& namespace_)>& M)
 {
-	{  // mvsim::UnexpectedMessageException file:mvsim/Comms/common.h line:49
+	{  // mvsim::UnexpectedMessageException file:mvsim/Comms/common.h line:51
 		pybind11::class_<
 			mvsim::UnexpectedMessageException, std::shared_ptr<mvsim::UnexpectedMessageException>,
 			PyCallBack_mvsim_UnexpectedMessageException, std::runtime_error>
@@ -64,8 +58,7 @@ void bind_mvsim_Comms_common(std::function<pybind11::module&(std::string const& 
 														UnexpectedMessageException&)) &
 				mvsim::UnexpectedMessageException::operator=,
 			"C++: mvsim::UnexpectedMessageException::operator=(const class "
-			"mvsim::UnexpectedMessageException &) --> class "
-			"mvsim::UnexpectedMessageException &",
+			"mvsim::UnexpectedMessageException &) --> class mvsim::UnexpectedMessageException &",
 			pybind11::return_value_policy::automatic, pybind11::arg(""));
 	}
 }

--- a/modules/comms/python/generated-sources-pybind/mvsim/Comms/common.cpp
+++ b/modules/comms/python/generated-sources-pybind/mvsim/Comms/common.cpp
@@ -29,7 +29,12 @@ struct PyCallBack_mvsim_UnexpectedMessageException : public mvsim::UnexpectedMes
 			auto o = overload.operator()<pybind11::return_value_policy::reference>();
 			if (pybind11::detail::cast_is_temporary_value_reference<const char*>::value)
 			{
+// pybind11 <=2.4: overload_caster_t, otherwise: override_caster_t
+#if (PYBIND11_MAJOR_VERSION == 2 && PYBIND11_MINOR_VERSION <= 4)
+				static pybind11::detail::overload_caster_t<const char*> caster;
+#else
 				static pybind11::detail::override_caster_t<const char*> caster;
+#endif
 				return pybind11::detail::cast_ref<const char*>(std::move(o), caster);
 			}
 			return pybind11::detail::cast_safe<const char*>(std::move(o));

--- a/modules/comms/python/generated-sources-pybind/pymvsim_comms.cpp
+++ b/modules/comms/python/generated-sources-pybind/pymvsim_comms.cpp
@@ -7,7 +7,7 @@
 #include <stdexcept>
 #include <string>
 
-typedef std::function<pybind11::module&(std::string const&)> ModuleGetter;
+using ModuleGetter = std::function<pybind11::module&(std::string const&)>;
 
 void bind_std_exception(std::function<pybind11::module&(std::string const& namespace_)>& M);
 void bind_std_stdexcept(std::function<pybind11::module&(std::string const& namespace_)>& M);
@@ -42,8 +42,7 @@ PYBIND11_MODULE(pymvsim_comms, root_module)
 			if (std::find(reserved_python_words.begin(), reserved_python_words.end(), ns) ==
 				reserved_python_words.end())
 				return ns;
-			else
-				return ns + '_';
+			return ns + '_';
 		});
 
 	std::vector<std::pair<std::string, std::string>> sub_modules{
@@ -51,7 +50,7 @@ PYBIND11_MODULE(pymvsim_comms, root_module)
 		{"", "std"},
 	};
 	for (auto& p : sub_modules)
-		modules[p.first.size() ? p.first + "::" + p.second : p.second] =
+		modules[p.first.empty() ? p.second : p.first + "::" + p.second] =
 			modules[p.first].def_submodule(
 				mangle_namespace_name(p.second).c_str(),
 				("Bindings for " + p.first + "::" + p.second + " namespace").c_str());

--- a/modules/comms/python/generated-sources-pybind/std/exception.cpp
+++ b/modules/comms/python/generated-sources-pybind/std/exception.cpp
@@ -8,8 +8,8 @@
 
 #ifndef BINDER_PYBIND11_TYPE_CASTER
 #define BINDER_PYBIND11_TYPE_CASTER
-PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)
-PYBIND11_DECLARE_HOLDER_TYPE(T, T*)
+PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>, false)
+PYBIND11_DECLARE_HOLDER_TYPE(T, T*, false)
 PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>)
 #endif
 
@@ -28,16 +28,10 @@ struct PyCallBack_std_exception : public std::exception
 			auto o = overload.operator()<pybind11::return_value_policy::reference>();
 			if (pybind11::detail::cast_is_temporary_value_reference<const char*>::value)
 			{
-// pybind11 <=2.4: overload_caster_t, otherwise: override_caster_t
-#if (PYBIND11_MAJOR_VERSION == 2 && PYBIND11_MINOR_VERSION <= 4)
-				static pybind11::detail::overload_caster_t<const char*> caster;
-#else
 				static pybind11::detail::override_caster_t<const char*> caster;
-#endif
 				return pybind11::detail::cast_ref<const char*>(std::move(o), caster);
 			}
-			else
-				return pybind11::detail::cast_safe<const char*>(std::move(o));
+			return pybind11::detail::cast_safe<const char*>(std::move(o));
 		}
 		return exception::what();
 	}
@@ -58,8 +52,8 @@ void bind_std_exception(std::function<pybind11::module&(std::string const& names
 			"assign",
 			(class std::exception & (std::exception::*)(const class std::exception&)) &
 				std::exception::operator=,
-			"C++: std::exception::operator=(const class std::exception &) --> "
-			"class std::exception &",
+			"C++: std::exception::operator=(const class std::exception &) --> class std::exception "
+			"&",
 			pybind11::return_value_policy::automatic, pybind11::arg(""));
 		cl.def(
 			"what", (const char* (std::exception::*)() const) & std::exception::what,

--- a/modules/comms/python/generated-sources-pybind/std/exception.cpp
+++ b/modules/comms/python/generated-sources-pybind/std/exception.cpp
@@ -28,7 +28,12 @@ struct PyCallBack_std_exception : public std::exception
 			auto o = overload.operator()<pybind11::return_value_policy::reference>();
 			if (pybind11::detail::cast_is_temporary_value_reference<const char*>::value)
 			{
+// pybind11 <=2.4: overload_caster_t, otherwise: override_caster_t
+#if (PYBIND11_MAJOR_VERSION == 2 && PYBIND11_MINOR_VERSION <= 4)
+				static pybind11::detail::overload_caster_t<const char*> caster;
+#else
 				static pybind11::detail::override_caster_t<const char*> caster;
+#endif
 				return pybind11::detail::cast_ref<const char*>(std::move(o), caster);
 			}
 			return pybind11::detail::cast_safe<const char*>(std::move(o));

--- a/modules/comms/python/generated-sources-pybind/std/stdexcept.cpp
+++ b/modules/comms/python/generated-sources-pybind/std/stdexcept.cpp
@@ -30,7 +30,12 @@ struct PyCallBack_std_runtime_error : public std::runtime_error
 			auto o = overload.operator()<pybind11::return_value_policy::reference>();
 			if (pybind11::detail::cast_is_temporary_value_reference<const char*>::value)
 			{
+// pybind11 <=2.4: overload_caster_t, otherwise: override_caster_t
+#if (PYBIND11_MAJOR_VERSION == 2 && PYBIND11_MINOR_VERSION <= 4)
+				static pybind11::detail::overload_caster_t<const char*> caster;
+#else
 				static pybind11::detail::override_caster_t<const char*> caster;
+#endif
 				return pybind11::detail::cast_ref<const char*>(std::move(o), caster);
 			}
 			return pybind11::detail::cast_safe<const char*>(std::move(o));

--- a/modules/comms/python/generated-sources-pybind/std/stdexcept.cpp
+++ b/modules/comms/python/generated-sources-pybind/std/stdexcept.cpp
@@ -10,8 +10,8 @@
 
 #ifndef BINDER_PYBIND11_TYPE_CASTER
 #define BINDER_PYBIND11_TYPE_CASTER
-PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)
-PYBIND11_DECLARE_HOLDER_TYPE(T, T*)
+PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>, false)
+PYBIND11_DECLARE_HOLDER_TYPE(T, T*, false)
 PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>)
 #endif
 
@@ -30,16 +30,10 @@ struct PyCallBack_std_runtime_error : public std::runtime_error
 			auto o = overload.operator()<pybind11::return_value_policy::reference>();
 			if (pybind11::detail::cast_is_temporary_value_reference<const char*>::value)
 			{
-// pybind11 <=2.4: overload_caster_t, otherwise: override_caster_t
-#if (PYBIND11_MAJOR_VERSION == 2 && PYBIND11_MINOR_VERSION <= 4)
-				static pybind11::detail::overload_caster_t<const char*> caster;
-#else
 				static pybind11::detail::override_caster_t<const char*> caster;
-#endif
 				return pybind11::detail::cast_ref<const char*>(std::move(o), caster);
 			}
-			else
-				return pybind11::detail::cast_safe<const char*>(std::move(o));
+			return pybind11::detail::cast_safe<const char*>(std::move(o));
 		}
 		return runtime_error::what();
 	}
@@ -64,8 +58,8 @@ void bind_std_stdexcept(std::function<pybind11::module&(std::string const& names
 			"assign",
 			(class std::runtime_error & (std::runtime_error::*)(const class std::runtime_error&)) &
 				std::runtime_error::operator=,
-			"C++: std::runtime_error::operator=(const class std::runtime_error "
-			"&) --> class std::runtime_error &",
+			"C++: std::runtime_error::operator=(const class std::runtime_error &) --> class "
+			"std::runtime_error &",
 			pybind11::return_value_policy::automatic, pybind11::arg(""));
 		cl.def(
 			"what", (const char* (std::runtime_error::*)() const) & std::runtime_error::what,

--- a/modules/comms/src/Comms/Client.cpp
+++ b/modules/comms/src/Comms/Client.cpp
@@ -681,9 +681,9 @@ void Client::internalTopicUpdatesThread()
 #endif
 }
 
+#if defined(MVSIM_HAS_PYTHON)
 // Overload for python wrapper
-std::string Client::callService(
-	const std::string& serviceName, const std::string& inputSerializedMsg)
+py::bytes Client::callService(const std::string& serviceName, const std::string& inputSerializedMsg)
 {
 	MRPT_START
 #if defined(MVSIM_HAS_ZMQ) && defined(MVSIM_HAS_PROTOBUF)
@@ -691,10 +691,14 @@ std::string Client::callService(
 
 	std::string outMsgData, outMsgType;
 	doCallService(serviceName, inputSerializedMsg, std::nullopt, outMsgData, outMsgType);
-	return outMsgData;
+	// Return as bytes to avoid Pybind11 assuming it is a str and attempting utf-8 encoding
+	// which may fail with certain structures.
+	return py::bytes(outMsgData);
 #endif
 	MRPT_END
 }
+#endif
+
 /// Overload for python wrapper
 void Client::subscribeTopic(
 	const std::string& topicName,

--- a/modules/generate-python.sh
+++ b/modules/generate-python.sh
@@ -10,7 +10,11 @@ echo "System PYBIND11_VERSION: $PYBIND11_VERSION (Used for wrapper: $PYBIND11_MM
 
 mkdir -p $1/python/generated-sources-pybind
 
-$HOME/code/binder/build/source/binder \
+BINDER=$(command -v binder || echo "$HOME/code/binder/build/source/binder")
+
+MRPT_PATH="${MRPT_PATH:-/home/jlblanco/code/mrpt}"
+
+$BINDER \
 	--root-module=pymvsim_$1 \
 	--prefix $1/python/generated-sources-pybind/ \
 	--bind pymvsim_$1 \
@@ -21,12 +25,12 @@ $HOME/code/binder/build/source/binder \
 	-DMVSIM_HAS_PROTOBUF=1 \
 	-DMVSIM_HAS_ZMQ=1 \
 	-I$1/include \
-	-I/home/jlblanco/code/mrpt/build-Release/include/mrpt-configuration/ \
-	-I/home/jlblanco/code/mrpt/libs/system/include/ \
-	-I/home/jlblanco/code/mrpt/libs/core/include/ \
-	-I/home/jlblanco/code/mrpt/libs/typemeta/include \
-	-I/home/jlblanco/code/mrpt/libs/io/include/ \
-	-I/home/jlblanco/code/mrpt/libs/serialization/include/ \
-	-I/home/jlblanco/code/mrpt/libs/rtti/include/ \
-	-I/home/jlblanco/code/mrpt/libs/serialization/include/ \
-	-I/home/jlblanco/code/mrpt/libs/containers/include/ \
+	-I$MRPT_PATH/build-Release/include/mrpt-configuration/ \
+	-I$MRPT_PATH/libs/system/include/ \
+	-I$MRPT_PATH/libs/core/include/ \
+	-I$MRPT_PATH/libs/typemeta/include \
+	-I$MRPT_PATH/libs/io/include/ \
+	-I$MRPT_PATH/libs/serialization/include/ \
+	-I$MRPT_PATH/libs/rtti/include/ \
+	-I$MRPT_PATH/libs/serialization/include/ \
+	-I$MRPT_PATH/libs/containers/include/ \

--- a/modules/generate-python.sh
+++ b/modules/generate-python.sh
@@ -4,6 +4,8 @@
 PYBIND11_VERSION=$(dpkg -s pybind11-dev | grep '^Version:' | cut -d " " -f2)
 SYSTEM_PYBIND11_MM_VERSION=$(echo $PYBIND11_VERSION | cut -d. -f1).$(echo $PYBIND11_VERSION | cut -d. -f2)
 
+PYTHON_INCLUDE_PATH=$(python3 -c "from sysconfig import get_paths; print(get_paths()['include'])")
+
 PYBIND11_MM_VERSION=${PYBIND11_MM_VERSION:-$SYSTEM_PYBIND11_MM_VERSION}
 
 echo "System PYBIND11_VERSION: $PYBIND11_VERSION (Used for wrapper: $PYBIND11_MM_VERSION)"
@@ -24,7 +26,9 @@ $BINDER \
 	-std=c++17 -DNDEBUG \
 	-DMVSIM_HAS_PROTOBUF=1 \
 	-DMVSIM_HAS_ZMQ=1 \
+	-DMVSIM_HAS_PYTHON=1 \
 	-I$1/include \
+	-I$PYTHON_INCLUDE_PATH \
 	-I$MRPT_PATH/build-Release/include/mrpt-configuration/ \
 	-I$MRPT_PATH/libs/system/include/ \
 	-I$MRPT_PATH/libs/core/include/ \


### PR DESCRIPTION
Addresses #62 

This also makes some tweaks to the generate-python.sh script, and also regenerates the pybind11 wrappers. The diff is larger than I would expect, so not sure if there is a mismatch in binder version or other settings. Happy to make changes as needed.