### PR TITLE
[draft] Do not use std::string for pybind services

### DIFF
--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -263,6 +263,7 @@ if (pybind11_FOUND)
 		set(PYTHON_INSTALL_DIRECTORY ${CMAKE_INSTALL_PREFIX} CACHE PATH "Install prefix for python modules with 'make python-install'")
 	endif()
 
+	find_package(ament_cmake_python REQUIRED)
 	mvsim_ament_cmake_python_get_python_install_dir() # Gets PYTHON_INSTALL_DIR
 
 	# We need to do the install via a script run during "make install" so we can 
@@ -277,6 +278,18 @@ if (pybind11_FOUND)
 			COMMAND ${CMAKE_COMMAND} -P ${mvsim_BINARY_DIR}/install-python.cmake
 			DEPENDS mvsim-msgs pymvsim_comms
 			COMMENT "Running 'python-install'")
+
+	# Create colcon environment hook to set PYTHONPATH
+	file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/pythonpath.dsv
+	"prepend-non-duplicate;PYTHONPATH;${PYTHON_INSTALL_DIR}"
+	)
+
+	# Install it where colcon expects environment hooks
+	install(
+		FILES ${CMAKE_CURRENT_BINARY_DIR}/pythonpath.dsv
+		DESTINATION share/mvsim/environment
+	)
+
 endif()
 
 # ========================== Show results ====================================

--- a/modules/comms/include/mvsim/Comms/common.h
+++ b/modules/comms/include/mvsim/Comms/common.h
@@ -55,6 +55,7 @@ class UnexpectedMessageException : public std::runtime_error
 };
 namespace internal
 {
+/// Returns: message type name, serialized data
 std::tuple<std::string, std::string> parseMessageToParts(const zmq::message_t& msg);
 
 template <typename variant_t, size_t IDX = 0>
@@ -69,14 +70,15 @@ variant_t recursiveParse(const std::string& typeName, const std::string& seriali
 		{
 			bool ok = v.ParseFromString(serializedData);
 			if (!ok)
+			{
 				THROW_EXCEPTION_FMT(
-					"Format error: protobuf could not decode binary message of "
-					"type '%s'",
+					"Format error: protobuf could not decode binary message of type '%s'",
 					typeName.c_str());
+			}
 			return {v};
 		}
-		else
-			return recursiveParse<variant_t, IDX + 1>(typeName, serializedData);
+
+		return recursiveParse<variant_t, IDX + 1>(typeName, serializedData);
 	}
 	throw UnexpectedMessageException(
 		mrpt::format("Type '%s' not found in expected list of variant arguments.", typeName.c_str())

--- a/modules/comms/python/generated-sources-pybind/mvsim/Comms/Client.cpp
+++ b/modules/comms/python/generated-sources-pybind/mvsim/Comms/Client.cpp
@@ -1,6 +1,5 @@
 #include <mrpt/system/CTimeLogger.h>
 #include <mvsim/Comms/Client.h>
-#include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -10,6 +9,7 @@
 #include <sstream>	// __str__
 #include <string>
 #include <string_view>
+#include <vector>
 
 #ifndef BINDER_PYBIND11_TYPE_CASTER
 #define BINDER_PYBIND11_TYPE_CASTER
@@ -23,17 +23,14 @@ void bind_mvsim_Comms_Client(std::function<pybind11::module&(std::string const& 
 	{  // mvsim::Client file:mvsim/Comms/Client.h line:48
 		pybind11::class_<mvsim::Client, std::shared_ptr<mvsim::Client>> cl(
 			M("mvsim"), "Client",
-			"This is the connection of any user program with the MVSIM server, "
-			"so\n it can advertise and subscribe to topics and use remote "
-			"services.\n\n Users should instance a class mvsim::Client (C++) "
-			"or mvsim.Client (Python) to\n communicate with the simulation "
-			"runnin in mvsim::World or any other module.\n\n Usage:\n  - "
-			"Instantiate a Client object.\n  - Call connect(). It will return "
-			"immediately.\n  - The client will be working on the background as "
-			"long as the object is not\n destroyed.\n\n Messages and topics "
-			"are described as Protobuf messages, and communications\n are done "
-			"via ZMQ sockets.\n\n See: https://mvsimulator.readthedocs.io/\n\n "
-			"\n\n ");
+			"This is the connection of any user program with the MVSIM server, so\n it can "
+			"advertise and subscribe to topics and use remote services.\n\n Users should instance "
+			"a class mvsim::Client (C++) or mvsim.Client (Python) to\n communicate with the "
+			"simulation running in mvsim::World or any other module.\n\n Usage:\n  - Instantiate a "
+			"Client object.\n  - Call connect(). It will return immediately.\n  - The client will "
+			"be working on the background as long as the object is not\n destroyed.\n\n Messages "
+			"and topics are described as Protobuf messages, and communications\n are done via ZMQ "
+			"sockets.\n\n See: https://mvsimulator.readthedocs.io/\n\n \n\n ");
 		cl.def(pybind11::init([]() { return new mvsim::Client(); }));
 		cl.def(pybind11::init<const std::string&>(), pybind11::arg("nodeName"));
 
@@ -44,58 +41,60 @@ void bind_mvsim_Comms_Client(std::function<pybind11::module&(std::string const& 
 		cl.def(
 			"serverHostAddress",
 			(const std::string& (mvsim::Client::*)() const) & mvsim::Client::serverHostAddress,
-			"C++: mvsim::Client::serverHostAddress() const --> const "
-			"std::string &",
+			"C++: mvsim::Client::serverHostAddress() const --> const std::string &",
 			pybind11::return_value_policy::automatic);
 		cl.def(
 			"serverHostAddress",
 			(void(mvsim::Client::*)(const std::string&)) & mvsim::Client::serverHostAddress,
-			"C++: mvsim::Client::serverHostAddress(const std::string &) --> "
-			"void",
+			"C++: mvsim::Client::serverHostAddress(const std::string &) --> void",
 			pybind11::arg("serverIpOrAddressName"));
 		cl.def(
 			"connect", (void(mvsim::Client::*)()) & mvsim::Client::connect,
-			"Connects to the server in a parallel thread.\n  Default server "
-			"address is `localhost`, can be changed with\n "
-			"serverHostAddress().\n\nC++: mvsim::Client::connect() --> void");
+			"Connects to the server in a parallel thread.\n  Default server address is "
+			"`localhost`, can be changed with\n serverHostAddress().\n\nC++: "
+			"mvsim::Client::connect() --> void");
 		cl.def(
 			"connected", (bool(mvsim::Client::*)() const) & mvsim::Client::connected,
 			"Whether the client is correctly connected to the server. \n\nC++: "
 			"mvsim::Client::connected() const --> bool");
 		cl.def(
 			"shutdown", (void(mvsim::Client::*)()) & mvsim::Client::shutdown,
-			"Shutdowns the communication thread. Blocks until the thread is "
-			"stopped.\n There is no need to manually call this method, it is "
-			"called upon\n destruction. \n\nC++: mvsim::Client::shutdown() --> "
-			"void");
+			"Shutdowns the communication thread. Blocks until the thread is stopped.\n There is no "
+			"need to manually call this method, it is called upon\n destruction. \n\nC++: "
+			"mvsim::Client::shutdown() --> void");
 		cl.def(
 			"callService",
-			(std::string(mvsim::Client::*)(const std::string&, const std::string&)) &
+			(class std::vector<unsigned char>(mvsim::Client::*)(
+				const std::string&, const class std::vector<unsigned char>&)) &
 				mvsim::Client::callService,
-			"Overload for python wrapper\n\nC++: "
-			"mvsim::Client::callService(const std::string &, const std::string "
-			"&) --> std::string",
+			"Overload for python wrapper\n\nC++: mvsim::Client::callService(const std::string &, "
+			"const class std::vector<unsigned char> &) --> class std::vector<unsigned char>",
 			pybind11::arg("serviceName"), pybind11::arg("inputSerializedMsg"));
 		cl.def(
 			"subscribeTopic",
 			(void(mvsim::Client::*)(
 				const std::string&,
 				const class std::function<void(
-					const std::string&,
-					const class std::vector<
-						unsigned char, class std::allocator<unsigned char>>&)>&)) &
+					const std::string&, const class std::vector<unsigned char>&)>&)) &
 				mvsim::Client::subscribeTopic,
-			"Overload for python wrapper (callback accepts "
-			"bytes-string)\n\nC++: mvsim::Client::subscribeTopic(const "
-			"std::string &, const class std::function<void (const std::string "
-			"&, const class std::vector<unsigned char, class "
-			"std::allocator<unsigned char> > &)> &) --> void",
+			"Overload for python wrapper (callback accepts bytes-string)\n\nC++: "
+			"mvsim::Client::subscribeTopic(const std::string &, const class std::function<void "
+			"(const std::string &, const class std::vector<unsigned char> &)> &) --> void",
+			pybind11::arg("topicName"), pybind11::arg("callback"));
+		cl.def(
+			"subscribe_topic_raw",
+			(void(mvsim::Client::*)(
+				const std::string&,
+				const class std::function<void(const class zmq::message_t&)>&)) &
+				mvsim::Client::subscribe_topic_raw,
+			"C++: mvsim::Client::subscribe_topic_raw(const std::string &, const class "
+			"std::function<void (const class zmq::message_t &)> &) --> void",
 			pybind11::arg("topicName"), pybind11::arg("callback"));
 		cl.def(
 			"enable_profiler", (void(mvsim::Client::*)(bool)) & mvsim::Client::enable_profiler,
 			"C++: mvsim::Client::enable_profiler(bool) --> void", pybind11::arg("enable"));
 
-		{  // mvsim::Client::InfoPerNode file:mvsim/Comms/Client.h line:113
+		{  // mvsim::Client::InfoPerNode file:mvsim/Comms/Client.h line:116
 			auto& enclosing_class = cl;
 			pybind11::class_<
 				mvsim::Client::InfoPerNode, std::shared_ptr<mvsim::Client::InfoPerNode>>
@@ -110,12 +109,11 @@ void bind_mvsim_Comms_Client(std::function<pybind11::module&(std::string const& 
 				 (mvsim::Client::InfoPerNode::*)(const struct mvsim::Client::InfoPerNode&)) &
 					mvsim::Client::InfoPerNode::operator=,
 				"C++: mvsim::Client::InfoPerNode::operator=(const struct "
-				"mvsim::Client::InfoPerNode &) --> struct "
-				"mvsim::Client::InfoPerNode &",
+				"mvsim::Client::InfoPerNode &) --> struct mvsim::Client::InfoPerNode &",
 				pybind11::return_value_policy::automatic, pybind11::arg(""));
 		}
 
-		{  // mvsim::Client::InfoPerTopic file:mvsim/Comms/Client.h line:119
+		{  // mvsim::Client::InfoPerTopic file:mvsim/Comms/Client.h line:122
 			auto& enclosing_class = cl;
 			pybind11::class_<
 				mvsim::Client::InfoPerTopic, std::shared_ptr<mvsim::Client::InfoPerTopic>>
@@ -133,8 +131,7 @@ void bind_mvsim_Comms_Client(std::function<pybind11::module&(std::string const& 
 				 (mvsim::Client::InfoPerTopic::*)(const struct mvsim::Client::InfoPerTopic&)) &
 					mvsim::Client::InfoPerTopic::operator=,
 				"C++: mvsim::Client::InfoPerTopic::operator=(const struct "
-				"mvsim::Client::InfoPerTopic &) --> struct "
-				"mvsim::Client::InfoPerTopic &",
+				"mvsim::Client::InfoPerTopic &) --> struct mvsim::Client::InfoPerTopic &",
 				pybind11::return_value_policy::automatic, pybind11::arg(""));
 		}
 	}

--- a/modules/comms/python/generated-sources-pybind/mvsim/Comms/common.cpp
+++ b/modules/comms/python/generated-sources-pybind/mvsim/Comms/common.cpp
@@ -14,7 +14,7 @@ PYBIND11_DECLARE_HOLDER_TYPE(T, T*)
 PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>)
 #endif
 
-// mvsim::UnexpectedMessageException file:mvsim/Comms/common.h line:49
+// mvsim::UnexpectedMessageException file:mvsim/Comms/common.h line:51
 struct PyCallBack_mvsim_UnexpectedMessageException : public mvsim::UnexpectedMessageException
 {
 	using mvsim::UnexpectedMessageException::UnexpectedMessageException;
@@ -29,12 +29,7 @@ struct PyCallBack_mvsim_UnexpectedMessageException : public mvsim::UnexpectedMes
 			auto o = overload.operator()<pybind11::return_value_policy::reference>();
 			if (pybind11::detail::cast_is_temporary_value_reference<const char*>::value)
 			{
-// pybind11 <=2.4: overload_caster_t, otherwise: override_caster_t
-#if (PYBIND11_MAJOR_VERSION == 2 && PYBIND11_MINOR_VERSION <= 4)
-				static pybind11::detail::overload_caster_t<const char*> caster;
-#else
 				static pybind11::detail::override_caster_t<const char*> caster;
-#endif
 				return pybind11::detail::cast_ref<const char*>(std::move(o), caster);
 			}
 			else
@@ -46,7 +41,7 @@ struct PyCallBack_mvsim_UnexpectedMessageException : public mvsim::UnexpectedMes
 
 void bind_mvsim_Comms_common(std::function<pybind11::module&(std::string const& namespace_)>& M)
 {
-	{  // mvsim::UnexpectedMessageException file:mvsim/Comms/common.h line:49
+	{  // mvsim::UnexpectedMessageException file:mvsim/Comms/common.h line:51
 		pybind11::class_<
 			mvsim::UnexpectedMessageException, std::shared_ptr<mvsim::UnexpectedMessageException>,
 			PyCallBack_mvsim_UnexpectedMessageException, std::runtime_error>
@@ -64,8 +59,7 @@ void bind_mvsim_Comms_common(std::function<pybind11::module&(std::string const& 
 														UnexpectedMessageException&)) &
 				mvsim::UnexpectedMessageException::operator=,
 			"C++: mvsim::UnexpectedMessageException::operator=(const class "
-			"mvsim::UnexpectedMessageException &) --> class "
-			"mvsim::UnexpectedMessageException &",
+			"mvsim::UnexpectedMessageException &) --> class mvsim::UnexpectedMessageException &",
 			pybind11::return_value_policy::automatic, pybind11::arg(""));
 	}
 }

--- a/modules/comms/python/generated-sources-pybind/pymvsim_comms.cpp
+++ b/modules/comms/python/generated-sources-pybind/pymvsim_comms.cpp
@@ -10,6 +10,7 @@
 typedef std::function<pybind11::module&(std::string const&)> ModuleGetter;
 
 void bind_std_exception(std::function<pybind11::module&(std::string const& namespace_)>& M);
+void bind_std_stl_vector(std::function<pybind11::module&(std::string const& namespace_)>& M);
 void bind_std_stdexcept(std::function<pybind11::module&(std::string const& namespace_)>& M);
 void bind_mvsim_Comms_common(std::function<pybind11::module&(std::string const& namespace_)>& M);
 void bind_mvsim_Comms_Client(std::function<pybind11::module&(std::string const& namespace_)>& M);
@@ -59,6 +60,7 @@ PYBIND11_MODULE(pymvsim_comms, root_module)
 	// pybind11::class_<std::shared_ptr<void>>(M(""), "_encapsulated_data_");
 
 	bind_std_exception(M);
+	bind_std_stl_vector(M);
 	bind_std_stdexcept(M);
 	bind_mvsim_Comms_common(M);
 	bind_mvsim_Comms_Client(M);

--- a/modules/comms/python/generated-sources-pybind/pymvsim_comms.sources
+++ b/modules/comms/python/generated-sources-pybind/pymvsim_comms.sources
@@ -1,5 +1,6 @@
 pymvsim_comms.cpp
 std/exception.cpp
+std/stl_vector.cpp
 std/stdexcept.cpp
 mvsim/Comms/common.cpp
 mvsim/Comms/Client.cpp

--- a/modules/comms/python/generated-sources-pybind/std/exception.cpp
+++ b/modules/comms/python/generated-sources-pybind/std/exception.cpp
@@ -13,7 +13,7 @@ PYBIND11_DECLARE_HOLDER_TYPE(T, T*)
 PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>)
 #endif
 
-// std::exception file:bits/exception.h line:61
+// std::exception file:bits/exception.h line:59
 struct PyCallBack_std_exception : public std::exception
 {
 	using std::exception::exception;
@@ -28,12 +28,7 @@ struct PyCallBack_std_exception : public std::exception
 			auto o = overload.operator()<pybind11::return_value_policy::reference>();
 			if (pybind11::detail::cast_is_temporary_value_reference<const char*>::value)
 			{
-// pybind11 <=2.4: overload_caster_t, otherwise: override_caster_t
-#if (PYBIND11_MAJOR_VERSION == 2 && PYBIND11_MINOR_VERSION <= 4)
-				static pybind11::detail::overload_caster_t<const char*> caster;
-#else
 				static pybind11::detail::override_caster_t<const char*> caster;
-#endif
 				return pybind11::detail::cast_ref<const char*>(std::move(o), caster);
 			}
 			else
@@ -45,7 +40,7 @@ struct PyCallBack_std_exception : public std::exception
 
 void bind_std_exception(std::function<pybind11::module&(std::string const& namespace_)>& M)
 {
-	{  // std::exception file:bits/exception.h line:61
+	{  // std::exception file:bits/exception.h line:59
 		pybind11::class_<std::exception, std::shared_ptr<std::exception>, PyCallBack_std_exception>
 			cl(M("std"), "exception", "");
 		cl.def(pybind11::init(
@@ -58,8 +53,8 @@ void bind_std_exception(std::function<pybind11::module&(std::string const& names
 			"assign",
 			(class std::exception & (std::exception::*)(const class std::exception&)) &
 				std::exception::operator=,
-			"C++: std::exception::operator=(const class std::exception &) --> "
-			"class std::exception &",
+			"C++: std::exception::operator=(const class std::exception &) --> class std::exception "
+			"&",
 			pybind11::return_value_policy::automatic, pybind11::arg(""));
 		cl.def(
 			"what", (const char* (std::exception::*)() const) & std::exception::what,

--- a/modules/comms/python/generated-sources-pybind/std/stdexcept.cpp
+++ b/modules/comms/python/generated-sources-pybind/std/stdexcept.cpp
@@ -30,12 +30,7 @@ struct PyCallBack_std_runtime_error : public std::runtime_error
 			auto o = overload.operator()<pybind11::return_value_policy::reference>();
 			if (pybind11::detail::cast_is_temporary_value_reference<const char*>::value)
 			{
-// pybind11 <=2.4: overload_caster_t, otherwise: override_caster_t
-#if (PYBIND11_MAJOR_VERSION == 2 && PYBIND11_MINOR_VERSION <= 4)
-				static pybind11::detail::overload_caster_t<const char*> caster;
-#else
 				static pybind11::detail::override_caster_t<const char*> caster;
-#endif
 				return pybind11::detail::cast_ref<const char*>(std::move(o), caster);
 			}
 			else
@@ -64,8 +59,8 @@ void bind_std_stdexcept(std::function<pybind11::module&(std::string const& names
 			"assign",
 			(class std::runtime_error & (std::runtime_error::*)(const class std::runtime_error&)) &
 				std::runtime_error::operator=,
-			"C++: std::runtime_error::operator=(const class std::runtime_error "
-			"&) --> class std::runtime_error &",
+			"C++: std::runtime_error::operator=(const class std::runtime_error &) --> class "
+			"std::runtime_error &",
 			pybind11::return_value_policy::automatic, pybind11::arg(""));
 		cl.def(
 			"what", (const char* (std::runtime_error::*)() const) & std::runtime_error::what,

--- a/modules/comms/python/generated-sources-pybind/std/stl_vector.cpp
+++ b/modules/comms/python/generated-sources-pybind/std/stl_vector.cpp
@@ -1,0 +1,237 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <sstream>	// __str__
+#include <string>
+#include <vector>
+
+#ifndef BINDER_PYBIND11_TYPE_CASTER
+#define BINDER_PYBIND11_TYPE_CASTER
+PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)
+PYBIND11_DECLARE_HOLDER_TYPE(T, T*)
+PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>)
+#endif
+
+void bind_std_stl_vector(std::function<pybind11::module&(std::string const& namespace_)>& M)
+{
+	{  // std::vector file:bits/stl_vector.h line:425
+		pybind11::class_<std::vector<unsigned char>> cl(M("std"), "vector_unsigned_char_t", "");
+		cl.def(pybind11::init([]() { return new std::vector<unsigned char>(); }));
+		cl.def(pybind11::init<const class std::allocator<unsigned char>&>(), pybind11::arg("__a"));
+
+		cl.def(
+			pybind11::init([](unsigned long const& a0)
+						   { return new std::vector<unsigned char>(a0); }),
+			"doc", pybind11::arg("__n"));
+		cl.def(
+			pybind11::init<unsigned long, const class std::allocator<unsigned char>&>(),
+			pybind11::arg("__n"), pybind11::arg("__a"));
+
+		cl.def(
+			pybind11::init([](unsigned long const& a0, const unsigned char& a1)
+						   { return new std::vector<unsigned char>(a0, a1); }),
+			"doc", pybind11::arg("__n"), pybind11::arg("__value"));
+		cl.def(
+			pybind11::init<
+				unsigned long, const unsigned char&, const class std::allocator<unsigned char>&>(),
+			pybind11::arg("__n"), pybind11::arg("__value"), pybind11::arg("__a"));
+
+		cl.def(pybind11::init([](std::vector<unsigned char> const& o)
+							  { return new std::vector<unsigned char>(o); }));
+		cl.def(
+			pybind11::init<
+				const class std::vector<unsigned char>&,
+				const class std::allocator<unsigned char>&>(),
+			pybind11::arg("__x"), pybind11::arg("__a"));
+
+		cl.def(
+			"assign",
+			(class std::vector<unsigned char> &
+			 (std::vector<unsigned char>::*)(const class std::vector<unsigned char>&)) &
+				std::vector<unsigned char>::operator=,
+			"C++: std::vector<unsigned char>::operator=(const class std::vector<unsigned char> &) "
+			"--> class std::vector<unsigned char> &",
+			pybind11::return_value_policy::automatic, pybind11::arg("__x"));
+		cl.def(
+			"assign",
+			(void(std::vector<unsigned char>::*)(unsigned long, const unsigned char&)) &
+				std::vector<unsigned char>::assign,
+			"C++: std::vector<unsigned char>::assign(unsigned long, const unsigned char &) --> "
+			"void",
+			pybind11::arg("__n"), pybind11::arg("__val"));
+		cl.def(
+			"begin",
+			(class __gnu_cxx::__normal_iterator<unsigned char*, class std::vector<unsigned char>>(
+				std::vector<unsigned char>::*)()) &
+				std::vector<unsigned char>::begin,
+			"C++: std::vector<unsigned char>::begin() --> class "
+			"__gnu_cxx::__normal_iterator<unsigned char *, class std::vector<unsigned char> >");
+		cl.def(
+			"end",
+			(class __gnu_cxx::__normal_iterator<unsigned char*, class std::vector<unsigned char>>(
+				std::vector<unsigned char>::*)()) &
+				std::vector<unsigned char>::end,
+			"C++: std::vector<unsigned char>::end() --> class "
+			"__gnu_cxx::__normal_iterator<unsigned char *, class std::vector<unsigned char> >");
+		cl.def(
+			"cbegin",
+			(class __gnu_cxx::__normal_iterator<
+				const unsigned char*, class std::vector<unsigned char>>(
+				std::vector<unsigned char>::*)() const) &
+				std::vector<unsigned char>::cbegin,
+			"C++: std::vector<unsigned char>::cbegin() const --> class "
+			"__gnu_cxx::__normal_iterator<const unsigned char *, class std::vector<unsigned char> "
+			">");
+		cl.def(
+			"cend",
+			(class __gnu_cxx::__normal_iterator<
+				const unsigned char*, class std::vector<unsigned char>>(
+				std::vector<unsigned char>::*)() const) &
+				std::vector<unsigned char>::cend,
+			"C++: std::vector<unsigned char>::cend() const --> class "
+			"__gnu_cxx::__normal_iterator<const unsigned char *, class std::vector<unsigned char> "
+			">");
+		cl.def(
+			"size",
+			(unsigned long (std::vector<unsigned char>::*)() const) &
+				std::vector<unsigned char>::size,
+			"C++: std::vector<unsigned char>::size() const --> unsigned long");
+		cl.def(
+			"max_size",
+			(unsigned long (std::vector<unsigned char>::*)() const) &
+				std::vector<unsigned char>::max_size,
+			"C++: std::vector<unsigned char>::max_size() const --> unsigned long");
+		cl.def(
+			"resize",
+			(void(std::vector<unsigned char>::*)(unsigned long)) &
+				std::vector<unsigned char>::resize,
+			"C++: std::vector<unsigned char>::resize(unsigned long) --> void",
+			pybind11::arg("__new_size"));
+		cl.def(
+			"resize",
+			(void(std::vector<unsigned char>::*)(unsigned long, const unsigned char&)) &
+				std::vector<unsigned char>::resize,
+			"C++: std::vector<unsigned char>::resize(unsigned long, const unsigned char &) --> "
+			"void",
+			pybind11::arg("__new_size"), pybind11::arg("__x"));
+		cl.def(
+			"shrink_to_fit",
+			(void(std::vector<unsigned char>::*)()) & std::vector<unsigned char>::shrink_to_fit,
+			"C++: std::vector<unsigned char>::shrink_to_fit() --> void");
+		cl.def(
+			"capacity",
+			(unsigned long (std::vector<unsigned char>::*)() const) &
+				std::vector<unsigned char>::capacity,
+			"C++: std::vector<unsigned char>::capacity() const --> unsigned long");
+		cl.def(
+			"empty",
+			(bool(std::vector<unsigned char>::*)() const) & std::vector<unsigned char>::empty,
+			"C++: std::vector<unsigned char>::empty() const --> bool");
+		cl.def(
+			"reserve",
+			(void(std::vector<unsigned char>::*)(unsigned long)) &
+				std::vector<unsigned char>::reserve,
+			"C++: std::vector<unsigned char>::reserve(unsigned long) --> void",
+			pybind11::arg("__n"));
+		cl.def(
+			"__getitem__",
+			(unsigned char& (std::vector<unsigned char>::*)(unsigned long)) &
+				std::vector<unsigned char>::operator[],
+			"C++: std::vector<unsigned char>::operator[](unsigned long) --> unsigned char &",
+			pybind11::return_value_policy::automatic, pybind11::arg("__n"));
+		cl.def(
+			"at",
+			(unsigned char& (std::vector<unsigned char>::*)(unsigned long)) &
+				std::vector<unsigned char>::at,
+			"C++: std::vector<unsigned char>::at(unsigned long) --> unsigned char &",
+			pybind11::return_value_policy::automatic, pybind11::arg("__n"));
+		cl.def(
+			"front",
+			(unsigned char& (std::vector<unsigned char>::*)()) & std::vector<unsigned char>::front,
+			"C++: std::vector<unsigned char>::front() --> unsigned char &",
+			pybind11::return_value_policy::automatic);
+		cl.def(
+			"back",
+			(unsigned char& (std::vector<unsigned char>::*)()) & std::vector<unsigned char>::back,
+			"C++: std::vector<unsigned char>::back() --> unsigned char &",
+			pybind11::return_value_policy::automatic);
+		cl.def(
+			"data",
+			(unsigned char* (std::vector<unsigned char>::*)()) & std::vector<unsigned char>::data,
+			"C++: std::vector<unsigned char>::data() --> unsigned char *",
+			pybind11::return_value_policy::automatic);
+		cl.def(
+			"push_back",
+			(void(std::vector<unsigned char>::*)(const unsigned char&)) &
+				std::vector<unsigned char>::push_back,
+			"C++: std::vector<unsigned char>::push_back(const unsigned char &) --> void",
+			pybind11::arg("__x"));
+		cl.def(
+			"pop_back",
+			(void(std::vector<unsigned char>::*)()) & std::vector<unsigned char>::pop_back,
+			"C++: std::vector<unsigned char>::pop_back() --> void");
+		cl.def(
+			"insert",
+			(class __gnu_cxx::__normal_iterator<unsigned char*, class std::vector<unsigned char>>(
+				std::vector<unsigned char>::*)(
+				class __gnu_cxx::__normal_iterator<
+					const unsigned char*, class std::vector<unsigned char>>,
+				const unsigned char&)) &
+				std::vector<unsigned char>::insert,
+			"C++: std::vector<unsigned char>::insert(class __gnu_cxx::__normal_iterator<const "
+			"unsigned char *, class std::vector<unsigned char> >, const unsigned char &) --> class "
+			"__gnu_cxx::__normal_iterator<unsigned char *, class std::vector<unsigned char> >",
+			pybind11::arg("__position"), pybind11::arg("__x"));
+		cl.def(
+			"insert",
+			(class __gnu_cxx::__normal_iterator<unsigned char*, class std::vector<unsigned char>>(
+				std::vector<unsigned char>::*)(
+				class __gnu_cxx::__normal_iterator<
+					const unsigned char*, class std::vector<unsigned char>>,
+				unsigned long, const unsigned char&)) &
+				std::vector<unsigned char>::insert,
+			"C++: std::vector<unsigned char>::insert(class __gnu_cxx::__normal_iterator<const "
+			"unsigned char *, class std::vector<unsigned char> >, unsigned long, const unsigned "
+			"char &) --> class __gnu_cxx::__normal_iterator<unsigned char *, class "
+			"std::vector<unsigned char> >",
+			pybind11::arg("__position"), pybind11::arg("__n"), pybind11::arg("__x"));
+		cl.def(
+			"erase",
+			(class __gnu_cxx::__normal_iterator<unsigned char*, class std::vector<unsigned char>>(
+				std::vector<unsigned char>::*)(
+				class __gnu_cxx::__normal_iterator<
+					const unsigned char*, class std::vector<unsigned char>>)) &
+				std::vector<unsigned char>::erase,
+			"C++: std::vector<unsigned char>::erase(class __gnu_cxx::__normal_iterator<const "
+			"unsigned char *, class std::vector<unsigned char> >) --> class "
+			"__gnu_cxx::__normal_iterator<unsigned char *, class std::vector<unsigned char> >",
+			pybind11::arg("__position"));
+		cl.def(
+			"erase",
+			(class __gnu_cxx::__normal_iterator<unsigned char*, class std::vector<unsigned char>>(
+				std::vector<unsigned char>::*)(
+				class __gnu_cxx::__normal_iterator<
+					const unsigned char*, class std::vector<unsigned char>>,
+				class __gnu_cxx::__normal_iterator<
+					const unsigned char*, class std::vector<unsigned char>>)) &
+				std::vector<unsigned char>::erase,
+			"C++: std::vector<unsigned char>::erase(class __gnu_cxx::__normal_iterator<const "
+			"unsigned char *, class std::vector<unsigned char> >, class "
+			"__gnu_cxx::__normal_iterator<const unsigned char *, class std::vector<unsigned char> "
+			">) --> class __gnu_cxx::__normal_iterator<unsigned char *, class std::vector<unsigned "
+			"char> >",
+			pybind11::arg("__first"), pybind11::arg("__last"));
+		cl.def(
+			"swap",
+			(void(std::vector<unsigned char>::*)(class std::vector<unsigned char>&)) &
+				std::vector<unsigned char>::swap,
+			"C++: std::vector<unsigned char>::swap(class std::vector<unsigned char> &) --> void",
+			pybind11::arg("__x"));
+		cl.def(
+			"clear", (void(std::vector<unsigned char>::*)()) & std::vector<unsigned char>::clear,
+			"C++: std::vector<unsigned char>::clear() --> void");
+	}
+}

--- a/package.xml
+++ b/package.xml
@@ -53,8 +53,10 @@
   <test_depend      condition="$ROS_VERSION == 2">ament_lint_auto</test_depend>
   <test_depend      condition="$ROS_VERSION == 2">ament_lint_common</test_depend>
   <build_depend     condition="$ROS_VERSION == 2">ament_cmake_xmllint</build_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake_python</buildtool_depend>
   <!-- to recognize launch files -->
   <exec_depend      condition="$ROS_VERSION == 2">ros2launch</exec_depend>
+  <exec_depend      condition="$ROS_VERSION == 2">python3</exec_depend>
 
   <export>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>


### PR DESCRIPTION
Addresses #62.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Python environment hook installation to ensure modules are discoverable after installation

* **Refactor**
  * Updated Client service API to use binary message format instead of text strings
  * Enhanced message serialization with structured binary framing
  * Client instances now prevent unsafe copy and move operations

* **Chores**
  * Removed support for older library versions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->