### PR TITLE
Optional publish to ROS2 all CsvLogger entries

### DIFF
--- a/docs/vehicles.rst
+++ b/docs/vehicles.rst
@@ -763,6 +763,35 @@ MVSim uses the REP-105 standard coordinate frames:
 * ``base_footprint`` - Projection of base_link onto the ground plane
 * ``<sensor_name>`` - Individual sensor frames (camera, lidar, etc.)
 
+CSV Logger → ROS 2 publishing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If publishing log topics is enabled via ``publish_log_topics:=True``:
+
+
+.. code-block:: bash
+
+   ros2 launch mvsim launch_world.launch.py \
+      world_file:=my.world.xml \
+      publish_log_topics:=True
+
+these topics will be created (per vehicle, lazily on first data):
+
+
+* ``<VEH>/log/pose/Timestamp``          (Float64)
+* ``<VEH>/log/pose/q0x``                (Float64)
+* ``<VEH>/log/pose/q1y``                (Float64)
+* ``<VEH>/log/pose/dqx``                (Float64)
+
+...
+
+* ``<VEH>/log/wheel_1/torque``          (Float64)
+* ``<VEH>/log/wheel_1/friction_x``      (Float64)
+
+...
+
+
+
 11. ROS 2 Subscribed Topics
 ----------------------------
 

--- a/launch/launch_world.launch.py
+++ b/launch/launch_world.launch.py
@@ -28,6 +28,11 @@ def generate_launch_description():
         "force_publish_vehicle_namespace", default_value='False',
         description='Use vehicle name namespace even if there is only one vehicle')
 
+    publish_log_topics_arg = DeclareLaunchArgument(
+        "publish_log_topics", default_value='False',
+        description='Publish every CSV-logger column as a std_msgs/Float64 topic per vehicle. '
+                    'High-rate, disabled by default.')
+
     use_rviz_arg = DeclareLaunchArgument(
         'use_rviz', default_value='True',
         description='Whether to launch RViz2'
@@ -50,6 +55,7 @@ def generate_launch_description():
                 "do_fake_localization": LaunchConfiguration('do_fake_localization'),
                 "publish_tf_odom2baselink": LaunchConfiguration('publish_tf_odom2baselink'),
                 "force_publish_vehicle_namespace": LaunchConfiguration('force_publish_vehicle_namespace'),
+                "publish_log_topics": LaunchConfiguration('publish_log_topics'),
             }]
     )
 
@@ -68,6 +74,7 @@ def generate_launch_description():
         do_fake_localization_arg,
         publish_tf_odom2baselink_arg,
         force_publish_vehicle_namespace_arg,
+        publish_log_topics_arg,
         use_rviz_arg,
         rviz_config_file_arg,
         mvsim_node,

--- a/modules/simulator/include/mvsim/CsvLogger.h
+++ b/modules/simulator/include/mvsim/CsvLogger.h
@@ -10,9 +10,11 @@
 #pragma once
 
 #include <fstream>
+#include <functional>
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
 /** \ingroup mvsim_simulator_module */
 class CSVLogger
@@ -22,6 +24,17 @@ class CSVLogger
 	virtual ~CSVLogger();
 
 	using Ptr = std::shared_ptr<CSVLogger>;
+
+	// deleted copy/move constructors and assignment operators:
+	CSVLogger(const CSVLogger&) = delete;
+	CSVLogger& operator=(const CSVLogger&) = delete;
+	CSVLogger(CSVLogger&&) = delete;
+	CSVLogger& operator=(CSVLogger&&) = delete;
+
+	/// Callback type invoked on each writeRow(), receiving the current
+	/// column name→value snapshot. Fired regardless of file-recording state.
+	using on_row_callback_t =
+		std::function<void(const std::map<std::string_view, double>& /*columns*/)>;
 
    public:
 	void updateColumn(const std::string_view& name, double value);
@@ -38,9 +51,23 @@ class CSVLogger
 	[[nodiscard]] bool isRecording() const { return isRecording_; }
 	void newSession();
 
+	/// Register a callback to be invoked on every writeRow().
+	/// \sa isActive()
+	void registerOnRowCallback(const on_row_callback_t& cb) { onRowCallbacks_.emplace_back(cb); }
+
+	/// Returns true when this logger should be "active" — i.e. columns
+	/// should be updated — because either file recording is on **or** at
+	/// least one listener callback is registered.
+	[[nodiscard]] bool isActive() const { return isRecording_ || !onRowCallbacks_.empty(); }
+
+	/// Read-only access to the current column values.
+	[[nodiscard]] const std::map<std::string_view, double>& getColumns() const { return columns_; }
+
    private:
 	std::map<std::string_view, double> columns_;
 	std::shared_ptr<std::ofstream> file_;
 	std::string filepath_;
 	bool isRecording_ = false;
+
+	std::vector<on_row_callback_t> onRowCallbacks_;
 };

--- a/modules/simulator/src/CsvLogger.cpp
+++ b/modules/simulator/src/CsvLogger.cpp
@@ -1,8 +1,18 @@
+/*+-------------------------------------------------------------------------+
+  |                       MultiVehicle simulator (libmvsim)                 |
+  |                                                                         |
+  | Copyright (C) 2014-2026  Jose Luis Blanco Claraco                       |
+  | Copyright (C) 2017  Borys Tymchenko (Odessa Polytechnic University)     |
+  | Distributed under 3-clause BSD License                                  |
+  |   See COPYING                                                           |
+  +-------------------------------------------------------------------------+ */
+
 #include "mvsim/CsvLogger.h"
 
 CSVLogger::CSVLogger() { file_ = std::make_shared<std::ofstream>(); }
 
 CSVLogger::~CSVLogger() { close(); }
+
 void CSVLogger::updateColumn(const std::string_view& name, double value) { columns_[name] = value; }
 
 bool CSVLogger::writeHeader()
@@ -29,9 +39,21 @@ bool CSVLogger::writeHeader()
 
 bool CSVLogger::writeRow()
 {
-	if (!isRecording_) return true;
+	// Always notify registered listeners, regardless of file recording:
+	for (const auto& cb : onRowCallbacks_)
+	{
+		cb(columns_);
+	}
 
-	if (!isOpen()) clear();
+	if (!isRecording_)
+	{
+		return true;
+	}
+
+	if (!isOpen())
+	{
+		clear();
+	}
 
 	for (auto it = columns_.begin(); it != columns_.end();)
 	{
@@ -73,7 +95,10 @@ bool CSVLogger::close()
 
 bool CSVLogger::clear()
 {
-	if (isOpen()) close();
+	if (isOpen())
+	{
+		close();
+	}
 
 	if (open())
 	{

--- a/modules/simulator/src/VehicleBase.cpp
+++ b/modules/simulator/src/VehicleBase.cpp
@@ -424,7 +424,7 @@ void VehicleBase::simul_pre_timestep(const TSimulContext& context)
 
 	for (size_t i = 0; i < getNumWheels(); i++)
 	{
-		if (auto& l = loggers_[LOGGER_IDX_WHEELS + i]; l->isRecording())
+		if (auto& l = loggers_[LOGGER_IDX_WHEELS + i]; l->isActive())
 		{
 			if (!frictions_.at(i)->hasLogger())
 			{
@@ -432,7 +432,6 @@ void VehicleBase::simul_pre_timestep(const TSimulContext& context)
 			}
 		}
 	}
-
 	// Update wheels position (they may turn, etc. as in an Ackermann
 	// configuration)
 	for (size_t i = 0; i < fixture_wheels_.size(); i++)
@@ -491,7 +490,7 @@ void VehicleBase::simul_pre_timestep(const TSimulContext& context)
 		b2dBody_->ApplyForce(wForce, wPt, true /*wake up*/);
 
 		// log
-		if (auto& l = loggers_[LOGGER_IDX_WHEELS + i]; l->isRecording())
+		if (auto& l = loggers_[LOGGER_IDX_WHEELS + i]; l->isActive())
 		{
 			auto& logger = *l;
 
@@ -499,7 +498,6 @@ void VehicleBase::simul_pre_timestep(const TSimulContext& context)
 			logger.updateColumn("wheel_pos_x", w.x);
 			logger.updateColumn("wheel_pos_y", w.y);
 
-			logger.updateColumn(DL_TIMESTAMP, context.simul_time);
 			logger.updateColumn(WL_TORQUE, fi.motorTorque);
 			logger.updateColumn(WL_FORCE_Z, fi.Fz);
 			logger.updateColumn(WL_VEL_X, fi.wheelCogLocalVel.x);
@@ -507,7 +505,6 @@ void VehicleBase::simul_pre_timestep(const TSimulContext& context)
 			logger.updateColumn(WL_FRIC_X, F_r.x);
 			logger.updateColumn(WL_FRIC_Y, F_r.y);
 		}
-
 		// save it for optional rendering:
 		if (world_->guiOptions_.show_forces)
 		{
@@ -584,7 +581,7 @@ void VehicleBase::simul_post_timestep(const TSimulContext& context)
 	const auto q = getPose();
 	const auto dq = getTwist();
 
-	if (auto& l = loggers_[LOGGER_IDX_POSE]; l->isRecording())
+	if (auto& l = loggers_[LOGGER_IDX_POSE]; l->isActive())
 	{
 		auto& logger = *l;
 		logger.updateColumn(DL_TIMESTAMP, context.simul_time);
@@ -892,7 +889,7 @@ void VehicleBase::writeLogStrings()
 {
 	for (auto& logger : loggers_)
 	{
-		if (!logger->isRecording())
+		if (!logger->isActive())
 		{
 			continue;
 		}
@@ -900,7 +897,6 @@ void VehicleBase::writeLogStrings()
 		logger->writeRow();
 	}
 }
-
 void VehicleBase::apply_force(
 	const mrpt::math::TVector2D& force, const mrpt::math::TPoint2D& applyPoint)
 {

--- a/mvsim_node_src/include/mvsim/mvsim_node_core.h
+++ b/mvsim_node_src/include/mvsim/mvsim_node_core.h
@@ -75,6 +75,7 @@ using Msg_CameraInfo = sensor_msgs::CameraInfo;
 #include <rclcpp/time_source.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <std_msgs/msg/bool.hpp>
+#include <std_msgs/msg/float64.hpp>
 #include <tf2/LinearMath/Transform.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
@@ -94,6 +95,7 @@ using Msg_OccupancyGrid = nav_msgs::msg::OccupancyGrid;
 using Msg_Odometry = nav_msgs::msg::Odometry;
 using Msg_MapMetaData = nav_msgs::msg::MapMetaData;
 using Msg_Bool = std_msgs::msg::Bool;
+using Msg_Float64 = std_msgs::msg::Float64;
 using Msg_TFMessage = tf2_msgs::msg::TFMessage;
 using Msg_MarkerArray = visualization_msgs::msg::MarkerArray;
 using Msg_CameraInfo = sensor_msgs::msg::CameraInfo;
@@ -171,6 +173,10 @@ class MVSimNode
 	bool publish_tf_odom2baselink_ = true;
 
 	int publisher_history_len_ = 50;
+
+	/// If true, publish each CSV-logger column as a Float64 topic per
+	/// vehicle at every simulation timestep. Disabled by default.
+	bool publish_log_topics_ = false;
 
    protected:
 #if defined(MVSIM_HAS_ZMQ) && defined(MVSIM_HAS_PROTOBUF)
@@ -262,6 +268,11 @@ class MVSimNode
 		rclcpp::Publisher<Msg_TFMessage>::SharedPtr pub_tf_static;
 
 		Msg_MarkerArray chassis_shape_msg;
+
+		/// Per-logger, per-column Float64 publishers for diagnostic topics.
+		/// Outer key = logger index, inner key = column name.
+		std::map<size_t, std::map<std::string, rclcpp::Publisher<Msg_Float64>::SharedPtr>>
+			pub_log_topics;
 #endif
 	};
 
@@ -273,6 +284,10 @@ class MVSimNode
 	/** Initialize all pub/subs required for each vehicle, for the specific
 	 * vehicle \a veh */
 	void initPubSubs(TPubSubPerVehicle& out_pubsubs, mvsim::VehicleBase* veh);
+
+	/// When publish_log_topics_==true, registers a per-column Float64
+	/// publisher callback on each of the vehicle's CSV loggers.
+	void initLoggerTopicCallbacks(TPubSubPerVehicle& pubsubs, mvsim::VehicleBase* veh);
 
 	// === End ROS Publishers ====
 

--- a/mvsim_tutorial/demo_1robot.launch.py
+++ b/mvsim_tutorial/demo_1robot.launch.py
@@ -26,7 +26,9 @@ def generate_launch_description():
     headless = LaunchConfiguration('headless')
     do_fake_localization = LaunchConfiguration('do_fake_localization')
     publish_tf_odom2baselink = LaunchConfiguration('publish_tf_odom2baselink')
-    force_publish_vehicle_namespace = LaunchConfiguration('force_publish_vehicle_namespace')
+    publish_log_topics = LaunchConfiguration('publish_log_topics')
+    force_publish_vehicle_namespace = LaunchConfiguration(
+        'force_publish_vehicle_namespace')
     use_rviz = LaunchConfiguration('use_rviz')
 
     # Create launch description
@@ -68,6 +70,14 @@ def generate_launch_description():
             description='Whether to launch RViz2'
         )
     )
+    ld.add_action(
+        DeclareLaunchArgument(
+            'publish_log_topics',
+            default_value='False',
+            description='Publish every CSV-logger column as a std_msgs/Float64 topic per vehicle. '
+                        'High-rate, disabled by default.'
+        )
+    )
 
     # Include world launch file
     ld.add_action(
@@ -85,6 +95,7 @@ def generate_launch_description():
                 'do_fake_localization': do_fake_localization,
                 'publish_tf_odom2baselink': publish_tf_odom2baselink,
                 'force_publish_vehicle_namespace': force_publish_vehicle_namespace,
+                'publish_log_topics': publish_log_topics,
                 'use_rviz': use_rviz,
                 'rviz_config_file': rviz_config_file
             }.items()

--- a/mvsim_tutorial/demo_2robots.launch.py
+++ b/mvsim_tutorial/demo_2robots.launch.py
@@ -15,6 +15,7 @@ def generate_launch_description():
     # Launch configuration variables (no defaults here)
     world_file = LaunchConfiguration('world_file')
     do_fake_localization = LaunchConfiguration('do_fake_localization')
+    publish_log_topics = LaunchConfiguration('publish_log_topics')
 
     # Declare launch arguments (defaults defined here)
     world_file_launch_arg = DeclareLaunchArgument(
@@ -27,7 +28,13 @@ def generate_launch_description():
     do_fake_localization_arg = DeclareLaunchArgument(
         'do_fake_localization',
         default_value='True',
-        description='Publish tf odom -> base_link'
+        description='Publish fake identity tf "map" -> "odom"'
+    )
+    publish_log_topics_arg = DeclareLaunchArgument(
+        'publish_log_topics',
+        default_value='False',
+        description='Publish every CSV-logger column as a std_msgs/Float64 topic per vehicle. '
+                    'High-rate, disabled by default.'
     )
 
     # MVSim node
@@ -41,6 +48,7 @@ def generate_launch_description():
             {
                 'world_file': world_file,
                 'do_fake_localization': do_fake_localization,
+                'publish_log_topics': publish_log_topics,
             }
         ]
     )
@@ -90,6 +98,7 @@ def generate_launch_description():
     return LaunchDescription([
         world_file_launch_arg,
         do_fake_localization_arg,
+        publish_log_topics_arg,
         mvsim_node,
         rviz2_r1_node,
         rviz2_r2_node

--- a/mvsim_tutorial/demo_depth_camera.launch.py
+++ b/mvsim_tutorial/demo_depth_camera.launch.py
@@ -1,12 +1,7 @@
-# ROS2 launch file, invoking mvsim/launch/launch_world.launch.py
+# ROS2 launch file for depth camera demo world
+# Invokes mvsim/launch/launch_world.launch.py
 # See: https://mvsimulator.readthedocs.io/en/latest/mvsim_node.html
 
-from launch.actions import IncludeLaunchDescription
-from launch.substitutions import TextSubstitution
-from launch_ros.actions import Node
-from launch.conditions import IfCondition
-from launch.actions import DeclareLaunchArgument
-from ament_index_python import get_package_share_directory
 import os
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
@@ -16,55 +11,95 @@ from ament_index_python.packages import get_package_share_directory
 
 
 def generate_launch_description():
-    # mvsim directory:
-    mvsimDir = get_package_share_directory("mvsim")
+    # Get mvsim package directory
+    mvsim_dir = get_package_share_directory('mvsim')
 
-    # World to launch:
+    # World and configuration files
     world_file = os.path.join(
-        mvsimDir, 'mvsim_tutorial', 'demo_depth_camera.world.xml')
+        mvsim_dir, 'mvsim_tutorial', 'demo_depth_camera.world.xml'
+    )
     rviz_config_file = os.path.join(
-        get_package_share_directory('mvsim'), 'mvsim_tutorial', 'demo_depth_camera_ros2.rviz')
+        mvsim_dir, 'mvsim_tutorial', 'demo_depth_camera_ros2.rviz'
+    )
 
-    # Configurable arguments
-    headless = LaunchConfiguration('headless', default='True')
-    do_fake_localization = LaunchConfiguration(
-        'do_fake_localization', default='False')
-    publish_tf_odom2baselink = LaunchConfiguration(
-        'publish_tf_odom2baselink', default='False')
+    # Launch configuration variables (no defaults here)
+    headless = LaunchConfiguration('headless')
+    do_fake_localization = LaunchConfiguration('do_fake_localization')
+    publish_tf_odom2baselink = LaunchConfiguration('publish_tf_odom2baselink')
+    publish_log_topics = LaunchConfiguration('publish_log_topics')
     force_publish_vehicle_namespace = LaunchConfiguration(
-        'force_publish_vehicle_namespace', default='True')
-    use_rviz = LaunchConfiguration('use_rviz', default='False')
+        'force_publish_vehicle_namespace')
+    use_rviz = LaunchConfiguration('use_rviz')
 
-    # Create LaunchDescription
+    # Create launch description
     ld = LaunchDescription()
 
-    # Add arguments to LaunchDescription
-    ld.add_action(DeclareLaunchArgument('headless', default_value='False',
-                                        description='Run in headless mode'))
-    ld.add_action(DeclareLaunchArgument('do_fake_localization', default_value='True',
-                                        description='Publish fake identity tf "map" -> "odom"'))
-    ld.add_action(DeclareLaunchArgument('publish_tf_odom2baselink', default_value='True',
-                                        description='Publish tf "odom" -> "base_link"'))
-    ld.add_action(DeclareLaunchArgument('force_publish_vehicle_namespace', default_value='False',
-                                        description='Use vehicle name namespace even if there is only one vehicle'))
-    ld.add_action(DeclareLaunchArgument('use_rviz', default_value='True',
-                                        description='Whether to launch RViz2'))
+    # Declare launch arguments (defaults defined here)
+    ld.add_action(
+        DeclareLaunchArgument(
+            'headless',
+            default_value='False',
+            description='Run in headless mode'
+        )
+    )
+    ld.add_action(
+        DeclareLaunchArgument(
+            'do_fake_localization',
+            default_value='True',
+            description='Publish fake identity tf "map" -> "odom"'
+        )
+    )
+    ld.add_action(
+        DeclareLaunchArgument(
+            'publish_tf_odom2baselink',
+            default_value='True',
+            description='Publish tf "odom" -> "base_link"'
+        )
+    )
+    ld.add_action(
+        DeclareLaunchArgument(
+            'force_publish_vehicle_namespace',
+            default_value='False',
+            description='Use vehicle name namespace even if there is only one vehicle'
+        )
+    )
+    ld.add_action(
+        DeclareLaunchArgument(
+            'use_rviz',
+            default_value='True',
+            description='Whether to launch RViz2'
+        )
+    )
+    ld.add_action(
+        DeclareLaunchArgument(
+            'publish_log_topics',
+            default_value='False',
+            description='Publish every CSV-logger column as a std_msgs/Float64 topic per vehicle. '
+                        'High-rate, disabled by default.'
+        )
+    )
 
-    # Include the original launch file
-    ld.add_action(IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            os.path.join(get_package_share_directory('mvsim'),
-                         'launch', 'launch_world.launch.py')
-        ),
-        launch_arguments={
-            'world_file': world_file,
-            'headless': headless,
-            'do_fake_localization': do_fake_localization,
-            'publish_tf_odom2baselink': publish_tf_odom2baselink,
-            'force_publish_vehicle_namespace': force_publish_vehicle_namespace,
-            'use_rviz': use_rviz,
-            'rviz_config_file': rviz_config_file
-        }.items()
-    ))
+    # Include world launch file
+    ld.add_action(
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                os.path.join(
+                    get_package_share_directory('mvsim'),
+                    'launch',
+                    'launch_world.launch.py'
+                )
+            ),
+            launch_arguments={
+                'world_file': world_file,
+                'headless': headless,
+                'do_fake_localization': do_fake_localization,
+                'publish_tf_odom2baselink': publish_tf_odom2baselink,
+                'force_publish_vehicle_namespace': force_publish_vehicle_namespace,
+                'publish_log_topics': publish_log_topics,
+                'use_rviz': use_rviz,
+                'rviz_config_file': rviz_config_file
+            }.items()
+        )
+    )
 
     return ld

--- a/mvsim_tutorial/demo_elevation_map.launch.py
+++ b/mvsim_tutorial/demo_elevation_map.launch.py
@@ -26,7 +26,9 @@ def generate_launch_description():
     headless = LaunchConfiguration('headless')
     do_fake_localization = LaunchConfiguration('do_fake_localization')
     publish_tf_odom2baselink = LaunchConfiguration('publish_tf_odom2baselink')
-    force_publish_vehicle_namespace = LaunchConfiguration('force_publish_vehicle_namespace')
+    publish_log_topics = LaunchConfiguration('publish_log_topics')
+    force_publish_vehicle_namespace = LaunchConfiguration(
+        'force_publish_vehicle_namespace')
     use_rviz = LaunchConfiguration('use_rviz')
 
     # Create launch description
@@ -68,6 +70,14 @@ def generate_launch_description():
             description='Whether to launch RViz2'
         )
     )
+    ld.add_action(
+        DeclareLaunchArgument(
+            'publish_log_topics',
+            default_value='False',
+            description='Publish every CSV-logger column as a std_msgs/Float64 topic per vehicle. '
+                        'High-rate, disabled by default.'
+        )
+    )
 
     # Include world launch file
     ld.add_action(
@@ -85,6 +95,7 @@ def generate_launch_description():
                 'do_fake_localization': do_fake_localization,
                 'publish_tf_odom2baselink': publish_tf_odom2baselink,
                 'force_publish_vehicle_namespace': force_publish_vehicle_namespace,
+                'publish_log_topics': publish_log_topics,
                 'use_rviz': use_rviz,
                 'rviz_config_file': rviz_config_file
             }.items()

--- a/mvsim_tutorial/demo_greenhouse.launch.py
+++ b/mvsim_tutorial/demo_greenhouse.launch.py
@@ -26,7 +26,9 @@ def generate_launch_description():
     headless = LaunchConfiguration('headless')
     do_fake_localization = LaunchConfiguration('do_fake_localization')
     publish_tf_odom2baselink = LaunchConfiguration('publish_tf_odom2baselink')
-    force_publish_vehicle_namespace = LaunchConfiguration('force_publish_vehicle_namespace')
+    publish_log_topics = LaunchConfiguration('publish_log_topics')
+    force_publish_vehicle_namespace = LaunchConfiguration(
+        'force_publish_vehicle_namespace')
     use_rviz = LaunchConfiguration('use_rviz')
 
     # Create launch description
@@ -68,6 +70,14 @@ def generate_launch_description():
             description='Whether to launch RViz2'
         )
     )
+    ld.add_action(
+        DeclareLaunchArgument(
+            'publish_log_topics',
+            default_value='False',
+            description='Publish every CSV-logger column as a std_msgs/Float64 topic per vehicle. '
+                        'High-rate, disabled by default.'
+        )
+    )
 
     # Include world launch file
     ld.add_action(
@@ -85,6 +95,7 @@ def generate_launch_description():
                 'do_fake_localization': do_fake_localization,
                 'publish_tf_odom2baselink': publish_tf_odom2baselink,
                 'force_publish_vehicle_namespace': force_publish_vehicle_namespace,
+                'publish_log_topics': publish_log_topics,
                 'use_rviz': use_rviz,
                 'rviz_config_file': rviz_config_file
             }.items()

--- a/mvsim_tutorial/demo_indoor_outdoor.launch.py
+++ b/mvsim_tutorial/demo_indoor_outdoor.launch.py
@@ -26,7 +26,9 @@ def generate_launch_description():
     headless = LaunchConfiguration('headless')
     do_fake_localization = LaunchConfiguration('do_fake_localization')
     publish_tf_odom2baselink = LaunchConfiguration('publish_tf_odom2baselink')
-    force_publish_vehicle_namespace = LaunchConfiguration('force_publish_vehicle_namespace')
+    publish_log_topics = LaunchConfiguration('publish_log_topics')
+    force_publish_vehicle_namespace = LaunchConfiguration(
+        'force_publish_vehicle_namespace')
     use_rviz = LaunchConfiguration('use_rviz')
 
     # Create launch description
@@ -68,6 +70,14 @@ def generate_launch_description():
             description='Whether to launch RViz2'
         )
     )
+    ld.add_action(
+        DeclareLaunchArgument(
+            'publish_log_topics',
+            default_value='False',
+            description='Publish every CSV-logger column as a std_msgs/Float64 topic per vehicle. '
+                        'High-rate, disabled by default.'
+        )
+    )
 
     # Include world launch file
     ld.add_action(
@@ -85,6 +95,7 @@ def generate_launch_description():
                 'do_fake_localization': do_fake_localization,
                 'publish_tf_odom2baselink': publish_tf_odom2baselink,
                 'force_publish_vehicle_namespace': force_publish_vehicle_namespace,
+                'publish_log_topics': publish_log_topics,
                 'use_rviz': use_rviz,
                 'rviz_config_file': rviz_config_file
             }.items()

--- a/mvsim_tutorial/demo_jackal.launch.py
+++ b/mvsim_tutorial/demo_jackal.launch.py
@@ -15,6 +15,7 @@ def generate_launch_description():
     # Launch configuration variables (no defaults here)
     world_file = LaunchConfiguration('world_file')
     do_fake_localization = LaunchConfiguration('do_fake_localization')
+    publish_log_topics = LaunchConfiguration('publish_log_topics')
 
     # Declare launch arguments (defaults defined here)
     world_file_launch_arg = DeclareLaunchArgument(
@@ -27,7 +28,13 @@ def generate_launch_description():
     do_fake_localization_arg = DeclareLaunchArgument(
         'do_fake_localization',
         default_value='True',
-        description='Publish tf odom -> base_link'
+        description='Publish fake identity tf "map" -> "odom"'
+    )
+    publish_log_topics_arg = DeclareLaunchArgument(
+        'publish_log_topics',
+        default_value='False',
+        description='Publish every CSV-logger column as a std_msgs/Float64 topic per vehicle. '
+                    'High-rate, disabled by default.'
     )
 
     # MVSim node
@@ -42,6 +49,7 @@ def generate_launch_description():
                 'world_file': world_file,
                 'headless': False,
                 'do_fake_localization': do_fake_localization,
+                'publish_log_topics': publish_log_topics,
             }
         ]
     )
@@ -54,12 +62,14 @@ def generate_launch_description():
         arguments=[
             '-d',
             os.path.join(mvsim_dir, 'mvsim_tutorial', 'demo_depth_camera_ros2.rviz')
-        ]
+        ],
+        output='screen'
     )
 
     return LaunchDescription([
         world_file_launch_arg,
         do_fake_localization_arg,
+        publish_log_topics_arg,
         mvsim_node,
         rviz2_node
     ])

--- a/mvsim_tutorial/demo_road_circuit1.launch.py
+++ b/mvsim_tutorial/demo_road_circuit1.launch.py
@@ -17,6 +17,7 @@ def generate_launch_description():
     world_file = LaunchConfiguration('world_file')
     headless = LaunchConfiguration('headless')
     do_fake_localization = LaunchConfiguration('do_fake_localization')
+    publish_log_topics = LaunchConfiguration('publish_log_topics')
     use_rviz = LaunchConfiguration('use_rviz')
 
     # Declare launch arguments (defaults defined here)
@@ -35,7 +36,13 @@ def generate_launch_description():
     do_fake_localization_arg = DeclareLaunchArgument(
         'do_fake_localization',
         default_value='True',
-        description='Publish tf odom -> base_link'
+        description='Publish fake identity tf "map" -> "odom"'
+    )
+    publish_log_topics_arg = DeclareLaunchArgument(
+        'publish_log_topics',
+        default_value='False',
+        description='Publish every CSV-logger column as a std_msgs/Float64 topic per vehicle. '
+                    'High-rate, disabled by default.'
     )
     use_rviz_arg = DeclareLaunchArgument(
         'use_rviz',
@@ -55,42 +62,42 @@ def generate_launch_description():
                 'world_file': world_file,
                 'headless': headless,
                 'do_fake_localization': do_fake_localization,
+                'publish_log_topics': publish_log_topics,
             }
         ]
     )
 
-    # RViz2 nodes for each robot
-    rviz2_nodes = [
-        Node(
-            condition=IfCondition(use_rviz),
-            package='rviz2',
-            executable='rviz2',
-            name='rviz2',
-            arguments=[
-                '-d',
-                os.path.join(mvsim_dir, 'mvsim_tutorial', 'demo_road_circuit1_ros2.rviz')
-            ],
-            output='screen',
-            remappings=[
-                ('/map', f'/r{idx}/map'),
-                ('/tf', f'/r{idx}/tf'),
-                ('/tf_static', f'/r{idx}/tf_static'),
-                ('/goal_pose', f'/r{idx}/goal_pose'),
-                ('/clicked_point', f'/r{idx}/clicked_point'),
-                ('/vehs/cmd_vel', f'/r{idx}/cmd_vel'),
-                ('/vehs/lidar1_points', f'/r{idx}/lidar1_points'),
-                ('/vehs/camera1/image_raw', f'/r{idx}/camera1/image_raw'),
-                ('/vehs/chassis_markers', f'/r{idx}/chassis_markers'),
-                ('/vehs/scanner1', f'/r{idx}/scanner1'),
-            ],
-        )
-        for idx in range(1, 2)
-    ]
+    # RViz2 node for robot r1
+    rviz2_node = Node(
+        condition=IfCondition(use_rviz),
+        package='rviz2',
+        executable='rviz2',
+        name='rviz2',
+        arguments=[
+            '-d',
+            os.path.join(mvsim_dir, 'mvsim_tutorial', 'demo_road_circuit1_ros2.rviz')
+        ],
+        output='screen',
+        remappings=[
+            ('/map', '/r1/map'),
+            ('/tf', '/r1/tf'),
+            ('/tf_static', '/r1/tf_static'),
+            ('/goal_pose', '/r1/goal_pose'),
+            ('/clicked_point', '/r1/clicked_point'),
+            ('/vehs/cmd_vel', '/r1/cmd_vel'),
+            ('/vehs/lidar1_points', '/r1/lidar1_points'),
+            ('/vehs/camera1/image_raw', '/r1/camera1/image_raw'),
+            ('/vehs/chassis_markers', '/r1/chassis_markers'),
+            ('/vehs/scanner1', '/r1/scanner1'),
+        ]
+    )
 
     return LaunchDescription([
         world_file_launch_arg,
         headless_launch_arg,
         do_fake_localization_arg,
+        publish_log_topics_arg,
         use_rviz_arg,
-        mvsim_node
-    ] + rviz2_nodes)
+        mvsim_node,
+        rviz2_node
+    ])

--- a/mvsim_tutorial/demo_turtlebot_world.launch.py
+++ b/mvsim_tutorial/demo_turtlebot_world.launch.py
@@ -26,7 +26,9 @@ def generate_launch_description():
     headless = LaunchConfiguration('headless')
     do_fake_localization = LaunchConfiguration('do_fake_localization')
     publish_tf_odom2baselink = LaunchConfiguration('publish_tf_odom2baselink')
-    force_publish_vehicle_namespace = LaunchConfiguration('force_publish_vehicle_namespace')
+    publish_log_topics = LaunchConfiguration('publish_log_topics')
+    force_publish_vehicle_namespace = LaunchConfiguration(
+        'force_publish_vehicle_namespace')
     use_rviz = LaunchConfiguration('use_rviz')
 
     # Create launch description
@@ -68,6 +70,14 @@ def generate_launch_description():
             description='Whether to launch RViz2'
         )
     )
+    ld.add_action(
+        DeclareLaunchArgument(
+            'publish_log_topics',
+            default_value='False',
+            description='Publish every CSV-logger column as a std_msgs/Float64 topic per vehicle. '
+                        'High-rate, disabled by default.'
+        )
+    )
 
     # Include world launch file
     ld.add_action(
@@ -85,6 +95,7 @@ def generate_launch_description():
                 'do_fake_localization': do_fake_localization,
                 'publish_tf_odom2baselink': publish_tf_odom2baselink,
                 'force_publish_vehicle_namespace': force_publish_vehicle_namespace,
+                'publish_log_topics': publish_log_topics,
                 'use_rviz': use_rviz,
                 'rviz_config_file': rviz_config_file
             }.items()

--- a/mvsim_tutorial/demo_warehouse.launch.py
+++ b/mvsim_tutorial/demo_warehouse.launch.py
@@ -26,7 +26,9 @@ def generate_launch_description():
     headless = LaunchConfiguration('headless')
     do_fake_localization = LaunchConfiguration('do_fake_localization')
     publish_tf_odom2baselink = LaunchConfiguration('publish_tf_odom2baselink')
-    force_publish_vehicle_namespace = LaunchConfiguration('force_publish_vehicle_namespace')
+    publish_log_topics = LaunchConfiguration('publish_log_topics')
+    force_publish_vehicle_namespace = LaunchConfiguration(
+        'force_publish_vehicle_namespace')
     use_rviz = LaunchConfiguration('use_rviz')
 
     # Create launch description
@@ -68,6 +70,14 @@ def generate_launch_description():
             description='Whether to launch RViz2'
         )
     )
+    ld.add_action(
+        DeclareLaunchArgument(
+            'publish_log_topics',
+            default_value='False',
+            description='Publish every CSV-logger column as a std_msgs/Float64 topic per vehicle. '
+                        'High-rate, disabled by default.'
+        )
+    )
 
     # Include world launch file
     ld.add_action(
@@ -85,6 +95,7 @@ def generate_launch_description():
                 'do_fake_localization': do_fake_localization,
                 'publish_tf_odom2baselink': publish_tf_odom2baselink,
                 'force_publish_vehicle_namespace': force_publish_vehicle_namespace,
+                'publish_log_topics': publish_log_topics,
                 'use_rviz': use_rviz,
                 'rviz_config_file': rviz_config_file
             }.items()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in support to publish CSV-logger columns as per-vehicle ROS 2 Float64 topics. Controlled by a new publish_log_topics parameter (default: disabled); topics are created lazily on first data for pose, wheel, and related columns.

* **Documentation**
  * New guide documenting how to enable and use CSV Logger → ROS 2 topic publishing with examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->