### PR TITLE
Lidar3D: fix min clip bug; add real intensity color

### DIFF
--- a/definitions/helios-32-FOV-26.sensor.xml
+++ b/definitions/helios-32-FOV-26.sensor.xml
@@ -24,14 +24,16 @@
     <vert_resolution_factor>${vert_resolution_factor|1.0}</vert_resolution_factor>
 
     <!-- Depth ratio (0 to 1) between adjacent depth image to allow linear interpolation of ranges -->
-    <max_vert_relative_depth_to_interpolatate>${max_vert_relative_depth_to_interpolatate|0.3}</max_vert_relative_depth_to_interpolatate>
-    <max_horz_relative_depth_to_interpolatate>${max_horz_relative_depth_to_interpolatate|0.1}</max_horz_relative_depth_to_interpolatate>
+    <max_vert_relative_depth_to_interpolate>${max_vert_relative_depth_to_interpolate|0.3}</max_vert_relative_depth_to_interpolate>
+    <max_horz_relative_depth_to_interpolate>${max_horz_relative_depth_to_interpolate|0.1}</max_horz_relative_depth_to_interpolate>
 
     <range_std_noise>${sensor_std_noise|0.005}</range_std_noise>
     <min_range>${min_range|0.20}</min_range>
     <max_range>${max_range|110.0}</max_range>
     
     <visual> <model_uri>${MVSIM_CURRENT_FILE_DIRECTORY}/../models/velodyne-vlp16.dae</model_uri> <model_roll>90</model_roll> </visual>
+
+    <generate_intensity>${generate_intensity|false}</generate_intensity>
 
     <!-- Publish sensor on MVSIM ZMQ topic? (Note, this is **not** related to ROS at all) -->
     <publish enabled="${sensor_publish|false}">

--- a/definitions/helios-32-FOV-31.sensor.xml
+++ b/definitions/helios-32-FOV-31.sensor.xml
@@ -24,14 +24,16 @@
     <vert_resolution_factor>${vert_resolution_factor|1.0}</vert_resolution_factor>
 
     <!-- Depth ratio (0 to 1) between adjacent depth image to allow linear interpolation of ranges -->
-    <max_vert_relative_depth_to_interpolatate>${max_vert_relative_depth_to_interpolatate|0.3}</max_vert_relative_depth_to_interpolatate>
-    <max_horz_relative_depth_to_interpolatate>${max_horz_relative_depth_to_interpolatate|0.1}</max_horz_relative_depth_to_interpolatate>
+    <max_vert_relative_depth_to_interpolate>${max_vert_relative_depth_to_interpolate|0.3}</max_vert_relative_depth_to_interpolate>
+    <max_horz_relative_depth_to_interpolate>${max_horz_relative_depth_to_interpolate|0.1}</max_horz_relative_depth_to_interpolate>
 
     <range_std_noise>${sensor_std_noise|0.005}</range_std_noise>
     <min_range>${min_range|0.20}</min_range>
     <max_range>${max_range|110.0}</max_range>
     
     <visual> <model_uri>${MVSIM_CURRENT_FILE_DIRECTORY}/../models/velodyne-vlp16.dae</model_uri> <model_roll>90</model_roll> </visual>
+
+    <generate_intensity>${generate_intensity|false}</generate_intensity>
 
     <!-- Publish sensor on MVSIM ZMQ topic? (Note, this is **not** related to ROS at all) -->
     <publish enabled="${sensor_publish|false}">

--- a/definitions/helios-32-FOV-70.sensor.xml
+++ b/definitions/helios-32-FOV-70.sensor.xml
@@ -24,14 +24,16 @@
     <vert_resolution_factor>${vert_resolution_factor|1.0}</vert_resolution_factor>
 
     <!-- Depth ratio (0 to 1) between adjacent depth image to allow linear interpolation of ranges -->
-    <max_vert_relative_depth_to_interpolatate>${max_vert_relative_depth_to_interpolatate|0.3}</max_vert_relative_depth_to_interpolatate>
-    <max_horz_relative_depth_to_interpolatate>${max_horz_relative_depth_to_interpolatate|0.1}</max_horz_relative_depth_to_interpolatate>
+    <max_vert_relative_depth_to_interpolate>${max_vert_relative_depth_to_interpolate|0.3}</max_vert_relative_depth_to_interpolate>
+    <max_horz_relative_depth_to_interpolate>${max_horz_relative_depth_to_interpolate|0.1}</max_horz_relative_depth_to_interpolate>
 
     <range_std_noise>${sensor_std_noise|0.005}</range_std_noise>
     <min_range>${min_range|0.20}</min_range>
     <max_range>${max_range|110.0}</max_range>
     
     <visual> <model_uri>${MVSIM_CURRENT_FILE_DIRECTORY}/../models/velodyne-vlp16.dae</model_uri> <model_roll>90</model_roll> </visual>
+
+    <generate_intensity>${generate_intensity|false}</generate_intensity>
 
     <!-- Publish sensor on MVSIM ZMQ topic? (Note, this is **not** related to ROS at all) -->
     <publish enabled="${sensor_publish|false}">

--- a/definitions/jackal.vehicle.xml
+++ b/definitions/jackal.vehicle.xml
@@ -71,6 +71,7 @@
         sensor_publish="false"
         sensor_name="lidar1"
         sensor_rate="10.0"
+        generate_intensity="true"
         horz_resolution_factor="1.5"
         vert_resolution_factor="1.0"
       />

--- a/definitions/ouster-os1.sensor.xml
+++ b/definitions/ouster-os1.sensor.xml
@@ -25,14 +25,16 @@
     <vert_resolution_factor>${vert_resolution_factor|1.0}</vert_resolution_factor>
 
     <!-- Depth ratio (0 to 1) between adjacent depth image to allow linear interpolation of ranges -->
-    <max_vert_relative_depth_to_interpolatate>${max_vert_relative_depth_to_interpolatate|0.3}</max_vert_relative_depth_to_interpolatate>
-    <max_horz_relative_depth_to_interpolatate>${max_horz_relative_depth_to_interpolatate|0.1}</max_horz_relative_depth_to_interpolatate>
+    <max_vert_relative_depth_to_interpolate>${max_vert_relative_depth_to_interpolate|0.3}</max_vert_relative_depth_to_interpolate>
+    <max_horz_relative_depth_to_interpolate>${max_horz_relative_depth_to_interpolate|0.1}</max_horz_relative_depth_to_interpolate>
 
     <range_std_noise>${sensor_std_noise|0.005}</range_std_noise>
     <min_range>${min_range|0.5}</min_range>
     <max_range>${max_range|90.0}</max_range>
     
     <visual> <model_uri>${MVSIM_CURRENT_FILE_DIRECTORY}/../models/velodyne-vlp16.dae</model_uri> <model_roll>90</model_roll> </visual>
+
+    <generate_intensity>${generate_intensity|false}</generate_intensity>
 
     <!-- Publish sensor on MVSIM ZMQ topic? (Note, this is **not** related to ROS at all) -->
     <publish enabled="${sensor_publish|false}">

--- a/definitions/velodyne-vlp16.sensor.xml
+++ b/definitions/velodyne-vlp16.sensor.xml
@@ -21,13 +21,15 @@
     <vert_resolution_factor>${vert_resolution_factor|1.0}</vert_resolution_factor>
 
     <!-- Depth ratio (0 to 1) between adjacent depth image to allow linear interpolation of ranges -->
-    <max_vert_relative_depth_to_interpolatate>${max_vert_relative_depth_to_interpolatate|0.3}</max_vert_relative_depth_to_interpolatate>
-    <max_horz_relative_depth_to_interpolatate>${max_horz_relative_depth_to_interpolatate|0.1}</max_horz_relative_depth_to_interpolatate>
+    <max_vert_relative_depth_to_interpolate>${max_vert_relative_depth_to_interpolate|0.3}</max_vert_relative_depth_to_interpolate>
+    <max_horz_relative_depth_to_interpolate>${max_horz_relative_depth_to_interpolate|0.1}</max_horz_relative_depth_to_interpolate>
 
     <range_std_noise>${sensor_std_noise|0.005}</range_std_noise>
     <max_range>${max_range|80.0}</max_range>
     
     <visual> <model_uri>${MVSIM_CURRENT_FILE_DIRECTORY}/../models/velodyne-vlp16.dae</model_uri> <model_roll>90</model_roll> </visual>
+
+    <generate_intensity>${generate_intensity|false}</generate_intensity>
 
     <!-- Publish sensor on MVSIM ZMQ topic? (Note, this is **not** related to ROS at all) -->
     <publish enabled="${sensor_publish|false}">

--- a/modules/simulator/include/mvsim/Sensors/Lidar3D.h
+++ b/modules/simulator/include/mvsim/Sensors/Lidar3D.h
@@ -32,7 +32,6 @@ class Lidar3D : public SensorBase
 	DECLARES_REGISTER_SENSOR(Lidar3D)
    public:
 	Lidar3D(Simulable& parent, const rapidxml::xml_node<char>* root);
-	virtual ~Lidar3D();
 
 	// See docs in base class
 	virtual void loadConfigFrom(const rapidxml::xml_node<char>* root) override;
@@ -97,6 +96,10 @@ class Lidar3D : public SensorBase
 	std::mutex has_to_render_mtx_;
 
 	std::shared_ptr<mrpt::opengl::CFBORender> fbo_renderer_depth_;
+
+	/** If true, intensity values will be generated from the grayscale of
+	 *  the rendered RGB image for each lidar return. */
+	bool generateIntensityFromRGB_ = true;
 
 	struct PerRayLUT
 	{

--- a/mvsim_tutorial/demo_warehouse.world.xml
+++ b/mvsim_tutorial/demo_warehouse.world.xml
@@ -103,7 +103,8 @@
 	<include file="../definitions/jackal.vehicle.xml"
 		default_sensors="true"
 		lidar2d_raytrace="true"
-	/>  <!-- lidar2d_raytrace: Use accurate 3D raytrace mode for the 2D lidar sensor too -->
+	/>
+	<!-- lidar2d_raytrace: Use accurate 3D raytrace mode for the 2D lidar sensor too -->
 
 	<!-- ========================
 		   Vehicle(s) definition

--- a/mvsim_tutorial/demo_warehouse_ros2.rviz
+++ b/mvsim_tutorial/demo_warehouse_ros2.rviz
@@ -5,9 +5,6 @@ Panels:
     Property Tree Widget:
       Expanded:
         - /Global Options1
-        - /Status1
-        - /PointCloud21/Topic1
-        - /Image1
       Splitter Ratio: 0.5
     Tree Height: 367
   - Class: rviz_common/Selection
@@ -85,40 +82,6 @@ Visualization Manager:
                 {}
       Update Interval: 0
       Value: true
-    - Alpha: 1
-      Autocompute Intensity Bounds: true
-      Autocompute Value Bounds:
-        Max Value: 5.155786514282227
-        Min Value: -0.003440767526626587
-        Value: true
-      Axis: Z
-      Channel Name: intensity
-      Class: rviz_default_plugins/PointCloud2
-      Color: 255; 255; 255
-      Color Transformer: AxisColor
-      Decay Time: 0
-      Enabled: true
-      Invert Rainbow: false
-      Max Color: 255; 255; 255
-      Max Intensity: 4096
-      Min Color: 0; 0; 0
-      Min Intensity: 0
-      Name: PointCloud2
-      Position Transformer: XYZ
-      Selectable: true
-      Size (Pixels): 3
-      Size (m): 0.029999999329447746
-      Style: Flat Squares
-      Topic:
-        Depth: 5
-        Durability Policy: Volatile
-        Filter size: 10
-        History Policy: Keep Last
-        Reliability Policy: Reliable
-        Value: /lidar1_points
-      Use Fixed Frame: true
-      Use rainbow: true
-      Value: true
     - Class: rviz_default_plugins/Image
       Enabled: true
       Max Value: 1
@@ -152,22 +115,22 @@ Visualization Manager:
     - Alpha: 1
       Autocompute Intensity Bounds: true
       Autocompute Value Bounds:
-        Max Value: 10
-        Min Value: -10
+        Max Value: 0.25
+        Min Value: 0.25
         Value: true
       Axis: Z
-      Channel Name: intensity
+      Channel Name: x
       Class: rviz_default_plugins/LaserScan
       Color: 255; 255; 255
-      Color Transformer: Intensity
+      Color Transformer: AxisColor
       Decay Time: 0
       Enabled: true
       Invert Rainbow: false
-      Max Color: 255; 255; 255
+      Max Color: 192; 28; 40
       Max Intensity: 4096
-      Min Color: 0; 0; 0
+      Min Color: 224; 27; 36
       Min Intensity: 0
-      Name: LaserScan
+      Name: 2D LaserScan
       Position Transformer: XYZ
       Selectable: true
       Size (Pixels): 5
@@ -182,6 +145,40 @@ Visualization Manager:
         Value: /scanner1
       Use Fixed Frame: true
       Use rainbow: true
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 5.155093193054199
+        Min Value: -0.0027008354663848877
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: Intensity
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 0.9460627436637878
+      Min Color: 0; 0; 0
+      Min Intensity: 0.003921568859368563
+      Name: 3D LiDAR
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.029999999329447746
+      Style: Flat Squares
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /lidar1_points
+      Use Fixed Frame: true
+      Use rainbow: false
       Value: true
   Enabled: true
   Global Options:
@@ -229,25 +226,25 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz_default_plugins/Orbit
-      Distance: 14.2178955078125
+      Distance: 20.460582733154297
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: 4.292714595794678
-        Y: -0.6092475056648254
-        Z: -2.8178439140319824
+        X: 4.271472930908203
+        Y: -1.5889875888824463
+        Z: -2.3046798706054688
       Focal Shape Fixed Size: true
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.5853979587554932
+      Pitch: 0.5253980159759521
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 2.692251205444336
+      Yaw: 2.8772518634796143
     Saved: ~
 Window Geometry:
   Displays:


### PR DESCRIPTION
Closes #90 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed misspelled depth-interpolation parameters across multiple sensor configs.

* **New Features**
  * Added optional LiDAR intensity generation (configurable per sensor) derived from rendered RGB.
  * Enabled intensity generation for one vehicle sensor by default.

* **Visualization**
  * Added dedicated 3D LiDAR point cloud display and updated laser-scan color/channel settings in RViz layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->