### PR TITLE
fix: XYZ wheel-corner markers must not appear in camera/sensor images

### DIFF
--- a/modules/simulator/include/mvsim/VisualObject.h
+++ b/modules/simulator/include/mvsim/VisualObject.h
@@ -83,8 +83,8 @@ class VisualObject
 	std::shared_ptr<mrpt::opengl::CSetOfObjects> glCollision_;
 	int32_t glCustomVisualId_ = -1;
 
-	const bool insertCustomVizIntoViz_ = true;
-	const bool insertCustomVizIntoPhysical_ = true;
+	bool insertCustomVizIntoViz_ = true;
+	bool insertCustomVizIntoPhysical_ = true;
 
 	virtual void internalGuiUpdate(
 		const mrpt::optional_ref<mrpt::opengl::COpenGLScene>& viz,

--- a/modules/simulator/src/VehicleBase.cpp
+++ b/modules/simulator/src/VehicleBase.cpp
@@ -61,6 +61,12 @@ void register_all_veh_dynamics()
 VehicleBase::VehicleBase(World* parent, size_t nWheels)
 	: VisualObject(parent), Simulable(parent), fixture_wheels_(nWheels, nullptr)
 {
+	// VehicleBase manages its own physical-scene representation via
+	// glChassisPhysical_, so the custom visual (which carries wheel viz
+	// objects with XYZ-corner markers) must NOT be inserted into the physical
+	// scene, otherwise camera/lidar sensors would see the XYZ corners.
+	insertCustomVizIntoPhysical_ = false;
+
 	// Create wheels:
 	for (size_t i = 0; i < nWheels; i++)
 	{


### PR DESCRIPTION
## Summary

- When a vehicle has a `<visual>` XML tag (custom mesh), `VisualObject::guiUpdate` was inserting `glCustomVisual_` into **both** the viz scene and the physical scene.
- `glCustomVisual_` holds the viz-only wheel frames (`glWheelsViz_`, built with `isPhysicalScene=false`), which include the rotating XYZ-corner axis markers.
- Camera and LiDAR sensors render the **physical** scene, so they were seeing those axis markers.

**Fix:** make `insertCustomVizIntoPhysical_` a plain (non-const) `bool` in `VisualObject`, and set it to `false` in `VehicleBase`'s constructor. `VehicleBase` already maintains a dedicated physical representation (`glChassisPhysical_` + `glWheelsPhysical_` with `isPhysicalScene=true`), so `glCustomVisual_` has no business being in the physical scene.

Note: the earlier fix (commit `7ca05b4`) addressed 3-D LiDARs for vehicles *without* a custom visual (the `isPhysicalScene` guard in `Wheel::getAs3DObject`). This PR addresses the remaining case: vehicles *with* a custom visual.

## Test plan

- [ ] Launch any demo world that uses a vehicle with a `<visual>` mesh (e.g. `demo_jackal.world.xml`) and verify that the camera/depth-camera image no longer shows the XYZ axis markers on the wheels.
- [ ] Verify that the XYZ corner markers are still visible in the main GUI 3-D view (viz scene unchanged).
- [ ] Build passes clang-format and clang-tidy cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where simulation sensors such as cameras and lidar could incorrectly detect vehicle visualization elements, improving sensor accuracy in simulations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MRPT/mvsim/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->