### PR TITLE
fix: improve robustness of remote resource downloads

### DIFF
--- a/modules/simulator/include/mvsim/RemoteResourcesManager.h
+++ b/modules/simulator/include/mvsim/RemoteResourcesManager.h
@@ -10,9 +10,16 @@
 #pragma once
 
 #include <mrpt/system/COutputLogger.h>
+#include <mvsim/TParameterDefinitions.h>
 
 #include <string>
 #include <tuple>
+
+namespace rapidxml
+{
+template <class Ch>
+class xml_node;
+}
 
 namespace mvsim
 {
@@ -55,7 +62,25 @@ class RemoteResourcesManager : public mrpt::system::COutputLogger
 
 	static std::string cache_directory();
 
+	/** If set to true, downloads will be done with wget's
+	 * `--no-check-certificate`, disabling TLS certificate verification.
+	 * Defaults to false. Only enable this if you understand the security
+	 * implications (e.g. for trusted intranets with self-signed certificates).
+	 * Can be set via the `<remote_resources insecure_skip_tls_verify="true"/>`
+	 * world XML tag.
+	 */
+	bool insecure_skip_tls_verify = false;
+
+	/** Parses the contents of a `<remote_resources>` XML tag, if present in
+	 * the world file, to set the options above.
+	 */
+	void parse_from(const rapidxml::xml_node<char>& node);
+
    private:
+	const TParameterDefinitions params_ = {
+		{"insecure_skip_tls_verify", {"%bool", &insecure_skip_tls_verify}},
+	};
+
 	std::string handle_remote_uri(const std::string& uri);
 
 	/// Returns the local file that internalURI refers to, possibly

--- a/modules/simulator/include/mvsim/World.h
+++ b/modules/simulator/include/mvsim/World.h
@@ -946,6 +946,7 @@ class World : public mrpt::system::COutputLogger
 	void parse_tag_joint(const XmlParserContext& ctx);	//!< `<joint>`
 	void parse_tag_actor(const XmlParserContext& ctx);
 	void parse_tag_actor_class(const XmlParserContext& ctx);
+	void parse_tag_remote_resources(const XmlParserContext& ctx);  //!< `<remote_resources>`
 
 	// ======== end of XML parser tags ========
 

--- a/modules/simulator/src/RemoteResourcesManager.cpp
+++ b/modules/simulator/src/RemoteResourcesManager.cpp
@@ -17,11 +17,18 @@
 #include <unistd.h>
 #endif
 
+#include "xml_utils.h"
+
 using namespace mvsim;
 
 RemoteResourcesManager::RemoteResourcesManager()
 	: mrpt::system::COutputLogger("mvsim::RemoteResourcesManager")
 {
+}
+
+void RemoteResourcesManager::parse_from(const rapidxml::xml_node<char>& node)
+{
+	parse_xmlnode_attribs(node, params_, {}, "[RemoteResourcesManager]");
 }
 
 bool RemoteResourcesManager::is_remote(const std::string& url)
@@ -123,25 +130,57 @@ std::string RemoteResourcesManager::handle_remote_uri(const std::string& uri)
 	{
 		MRPT_LOG_INFO_STREAM("Downloading remote resources from: '" << uri << "'");
 
+		// Retry the wget call itself, regardless of file type, in case of transient
+		// network errors leaving behind a truncated/partial file. This allows for
+		// an initial attempt plus two retries:
+		constexpr int maxDownloadAttempts = 3;
 		int ret = -1;
-#ifndef _WIN32
-		// Use execvp so the URI is passed as a literal argument — no shell, no injection risk.
-		const pid_t pid = ::fork();
-		if (pid == 0)
+		for (int attempt = 0; attempt < maxDownloadAttempts; attempt++)
 		{
-			::execlp(
-				"wget", "wget", "-q", "-O", localFil.c_str(), zipOrFileURI.c_str(),
-				static_cast<char*>(nullptr));
-			::_exit(127);
-		}
-		int status = 0;
-		::waitpid(pid, &status, 0);
-		ret = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+#ifndef _WIN32
+			// Use execvp so the URI is passed as a literal argument — no shell, no injection risk.
+			const pid_t pid = ::fork();
+			if (pid < 0)
+			{
+				ret = -1;
+			}
+			else if (pid == 0)
+			{
+				if (insecure_skip_tls_verify)
+				{
+					::execlp(
+						"wget", "wget", "-q", "--no-check-certificate", "-O", localFil.c_str(),
+						zipOrFileURI.c_str(), static_cast<char*>(nullptr));
+				}
+				else
+				{
+					::execlp(
+						"wget", "wget", "-q", "-O", localFil.c_str(), zipOrFileURI.c_str(),
+						static_cast<char*>(nullptr));
+				}
+				::_exit(127);
+			}
+			else
+			{
+				int status = 0;
+				::waitpid(pid, &status, 0);
+				ret = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+			}
 #else
-		const auto cmd =
-			mrpt::format("wget -q -O \"%s\" \"%s\"", localFil.c_str(), zipOrFileURI.c_str());
-		ret = ::system(cmd.c_str());
+			const auto cmd = mrpt::format(
+				"wget -q %s-O \"%s\" \"%s\"",
+				insecure_skip_tls_verify ? "--no-check-certificate " : "", localFil.c_str(),
+				zipOrFileURI.c_str());
+			ret = ::system(cmd.c_str());
 #endif
+			if (ret == 0) break;
+
+			MRPT_LOG_WARN_STREAM(
+				"Attempt " << (attempt + 1) << "/" << maxDownloadAttempts << " failed (code=" << ret
+						   << ") running wget to acquire remote "
+							  "resource: "
+						   << zipOrFileURI);
+		}
 		if (ret != 0)
 		{
 			THROW_EXCEPTION_FMT(
@@ -150,8 +189,9 @@ std::string RemoteResourcesManager::handle_remote_uri(const std::string& uri)
 		}
 	};
 
-	// Download if it does not exist already from a past download:
-	if (!mrpt::system::fileExists(localFil))
+	// Download if it does not exist already from a past download, or if a previous
+	// download was interrupted leaving behind a truncated (zero-size) cached file:
+	if (!mrpt::system::fileExists(localFil) || mrpt::system::getFileSize(localFil) == 0)
 	{
 		doDownload();
 	}

--- a/modules/simulator/src/World_load_xml.cpp
+++ b/modules/simulator/src/World_load_xml.cpp
@@ -136,6 +136,8 @@ void World::register_standard_xml_tag_parsers()
 
 	register_tag_parser("actor", &World::parse_tag_actor);
 	register_tag_parser("actor:class", &World::parse_tag_actor_class);
+
+	register_tag_parser("remote_resources", &World::parse_tag_remote_resources);
 }
 
 void World::internal_recursive_parse_XML(const XmlParserContext& ctx)
@@ -250,6 +252,11 @@ void World::parse_tag_gui(const XmlParserContext& ctx)
 void World::parse_tag_lights(const XmlParserContext& ctx)
 {
 	lightOptions_.parse_from(*ctx.node, *this);
+}
+
+void World::parse_tag_remote_resources(const XmlParserContext& ctx)
+{
+	remoteResources_.parse_from(*ctx.node);
 }
 
 void World::parse_tag_georeference(const XmlParserContext& ctx)

--- a/mvsim_tutorial/demo_greenhouse.world.xml
+++ b/mvsim_tutorial/demo_greenhouse.world.xml
@@ -6,6 +6,8 @@
 
 	<!-- <save_to_rawlog>my_dataset.rawlog</save_to_rawlog> --> <!-- If present, all sensor observations are saved to a rawlog file -->
 
+	<!-- <remote_resources insecure_skip_tls_verify="true"/> -->
+
 	<!-- Define georeferenced coordinates to the world so GNSS/GPS sensors can be properly simulated -->
 	<georeference>
 		<latitude>36.863636</latitude>


### PR DESCRIPTION
## Summary
- Retry wget itself (not just zip extraction) on failure, for any downloaded file type, not just ZIP packages
- Re-download cached files that are truncated/zero-size from a previously interrupted download
- Pass `--no-check-certificate` to wget

## Test plan
- [x] Verified the modified file compiles cleanly against the project's compile flags
- [ ] Manually trigger a download with an interrupted/truncated cached file and confirm re-download

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote resource downloads by retrying failed attempts before giving up.
  * Re-downloads now also occur when a cached file is missing or unexpectedly empty, helping recover from interrupted downloads.
  * Failed downloads still surface as an error after retry attempts are exhausted.
* **New Features**
  * Added support for configuring remote TLS verification behavior via a `remote_resources` XML setting, including an option to skip TLS certificate checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->