### PR TITLE
build: auto-enable ccache when available

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -57,6 +57,18 @@ jobs:
           git submodule sync
           git submodule update --init --recursive
 
+      - name: Install ccache
+        run: sudo apt-get install -y ccache
+
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ccache-${{ matrix.name }}-${{ matrix.build_type }}-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ matrix.name }}-${{ matrix.build_type }}-${{ github.ref }}-
+            ccache-${{ matrix.name }}-${{ matrix.build_type }}-
+
       - name: Install Dependencies
         run: |
           # See bug/issue: https://github.com/orgs/community/discussions/47863

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,16 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)  # optional, ensure standard is supported
 set(CMAKE_CXX_EXTENSIONS OFF)  # optional, keep compiler extensions off
 
 
+# Use ccache if available
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  message(STATUS "ccache found: ${CCACHE_PROGRAM}")
+  set(CMAKE_C_COMPILER_LAUNCHER   "${CCACHE_PROGRAM}")
+  set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+else()
+  message(STATUS "ccache not found; builds will not be cached")
+endif()
+
 find_package(Threads)
 include(GNUInstallDirs)
 include(cmake/mvsim_cmake_functions.cmake REQUIRED)


### PR DESCRIPTION
## Summary
- Detect `ccache` at CMake configure time via `find_program` and set it as `CMAKE_C_COMPILER_LAUNCHER` / `CMAKE_CXX_COMPILER_LAUNCHER` — zero-config for any developer who has ccache installed
- Add `ccache` install step to the CI `build-linux.yml` workflow
- Add `actions/cache@v4` step to persist `~/.ccache` across CI runs, keyed by matrix name, build type, and branch (with fallback restore keys for cross-branch hits)

## Test plan
- [ ] CI builds green on all four matrix entries (ubuntu-22/24 × gcc/clang)
- [ ] Second CI run shows cache hit and faster build times
- [ ] Local builds: if ccache is installed, `cmake ..` output should include `ccache found: /usr/bin/ccache`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Linux build caching to speed up compiler rebuilds and reduce CI build times.
  * Added support for using cached compiler outputs when available, with automatic fallback when caching isn’t present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->