### PR TITLE
fix: GNSS ROS publisher never set NavSatFix.status.status

### DIFF
--- a/mvsim_node_src/mvsim_node.cpp
+++ b/mvsim_node_src/mvsim_node.cpp
@@ -28,6 +28,7 @@
 // ===========================================
 //                    ROS 1
 // ===========================================
+#include <mrpt/ros1bridge/gps.h>
 #include <mrpt/ros1bridge/image.h>
 #include <mrpt/ros1bridge/imu.h>
 #include <mrpt/ros1bridge/laser_scan.h>
@@ -60,6 +61,7 @@ using Msg_Marker = visualization_msgs::Marker;
 // ===========================================
 //                    ROS 2
 // ===========================================
+#include <mrpt/ros2bridge/gps.h>
 #include <mrpt/ros2bridge/image.h>
 #include <mrpt/ros2bridge/imu.h>
 #include <mrpt/ros2bridge/laser_scan.h>
@@ -1291,31 +1293,21 @@ void MVSimNode::internalOn(const mvsim::VehicleBase& veh, const mrpt::obs::CObse
 
 	// Send observation:
 	{
-		// Convert observation MRPT -> ROS
+		// Convert observation MRPT -> ROS. Delegate to the library conversion
+		// (as the IMU handler above already does) instead of reimplementing it
+		// field-by-field: the hand-rolled version here never set
+		// msg->status.status, which ROS leaves at NavSatStatus::STATUS_UNKNOWN
+		// (-2) by IDL default; consumers that treat anything other than a
+		// definite fix as invalid (e.g. mola_state_estimation_smoother's GNSS
+		// fusion) would then silently reject every single reading, even
+		// though the simulated fix quality (mrpt::obs::gnss::Message_NMEA_GGA
+		// ::fields::fix_quality) was perfectly valid.
+		Msg_Header msg_header;
+		msg_header.stamp = myNow();
+		msg_header.frame_id = obs.sensorLabel;
+
 		auto msg = mvsim_node::make_shared<Msg_GPS>();
-		msg->header.stamp = myNow();
-		msg->header.frame_id = obs.sensorLabel;
-
-		const auto& o = obs.getMsgByClass<mrpt::obs::gnss::Message_NMEA_GGA>();
-
-		msg->latitude = o.fields.latitude_degrees;
-		msg->longitude = o.fields.longitude_degrees;
-		msg->altitude = o.fields.altitude_meters;
-
-		if (auto& c = obs.covariance_enu; c.has_value())
-		{
-#if PACKAGE_ROS_VERSION == 1
-			msg->position_covariance_type = sensor_msgs::NavSatFix::COVARIANCE_TYPE_DIAGONAL_KNOWN;
-#else
-			msg->position_covariance_type =
-				sensor_msgs::msg::NavSatFix::COVARIANCE_TYPE_DIAGONAL_KNOWN;
-#endif
-
-			msg->position_covariance.fill(0.0);
-			msg->position_covariance[0] = (*c)(0, 0);
-			msg->position_covariance[4] = (*c)(1, 1);
-			msg->position_covariance[8] = (*c)(2, 2);
-		}
+		mrpt2ros::toROS(obs, msg_header, *msg);
 
 		pub->publish(msg);
 	}


### PR DESCRIPTION
## Summary
Found via end-to-end MOLA + MVSIM simulation testing of GNSS-based robot localization: the simulated GNSS observation is converted to `sensor_msgs::NavSatFix` by hand, field by field (latitude/longitude/altitude/covariance only), and never touches `msg.status.status`. ROS leaves that field at `NavSatStatus::STATUS_UNKNOWN` (`-2`) by IDL default — not `STATUS_FIX` (`0`) as a naive zero-init might suggest.

Any consumer that treats anything other than a definite fix as invalid (e.g. `mola_state_estimation_smoother`'s GNSS fusion) silently rejects *every single* simulated GNSS reading, even though mvsim's own internal fix quality (`Message_NMEA_GGA::fields::fix_quality`, set in `Sensors/GNSS.cpp`) was perfectly valid the whole time. This makes any ROS 2 consumer relying on GNSS status filtering unable to use mvsim's simulated GNSS at all, silently (no error, no warning — the messages publish fine, just with an always-invalid status).

## Fix
Delegates to the existing, already-correct `mrpt2ros::toROS(CObservationGPS, Header, NavSatFix&)` bridge function — matching the pattern the adjacent IMU handler already used — instead of reimplementing the conversion by hand. The GPS bridge header (`<mrpt/ros1bridge/gps.h>` / `<mrpt/ros2bridge/gps.h>`) wasn't even included before.

## Test plan
- [x] `colcon test --packages-select mvsim`: 13/13 passed
- [x] clang-format-14 and clang-tidy clean (one pre-existing, unrelated clang-tidy warning elsewhere in the file, untouched by this diff)
- [x] End-to-end MOLA + MVSIM simulation: confirmed live via `ros2 topic echo`/DEBUG logs that GNSS readings are now accepted by a real ROS 2 consumer (`mola_state_estimation_smoother`'s `fuse_gnss()`), where every single reading was previously silently rejected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GPS fix status reporting so valid readings are correctly marked as available.
  * Improved GPS message conversion for consistent latitude, longitude, altitude, and covariance data across ROS1 and ROS2.
  * Prevented downstream systems from rejecting valid GPS readings due to an unknown status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->