### PR TITLE
feat: allow sensors' GUI preview subwindow to start minimized

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -86,6 +86,8 @@ Each vehicle type has companion `*_Controller*.cpp` files for its controllers (R
 | `IMU.cpp` / `ImuNoiseModel.cpp` | IMU with Forster 2016 noise model |
 | `GNSS.cpp` | GPS/GNSS with configurable noise |
 
+Cameras (`CameraSensor`, `DepthCameraSensor`) open a GUI preview subwindow showing their live image(s). The common `SensorBase` XML tag `<preview_win_visible>` (default `true`) controls whether that subwindow starts opened or minimized, without affecting the simulated sensor data itself.
+
 ### World elements (`src/WorldElements/`)
 
 `OccupancyGridMap`, `ElevationMap`, `HorizontalPlane`, `VerticalPlane`, `GroundGrid`, `PointCloud`, `SkyBox`, `PropertyRegion` (friction zones).

--- a/definitions/camera.sensor.xml
+++ b/definitions/camera.sensor.xml
@@ -16,6 +16,9 @@
     <clip_min>${clip_min|1e-2}</clip_min>
     <clip_max>${clip_max|1e+4}</clip_max>
 
+    <!-- Whether the GUI preview subwindow for this sensor starts opened (true, default) or minimized (false) -->
+    <preview_win_visible>${preview_win_visible|true}</preview_win_visible>
+
     <visual>
       <model_uri>${MVSIM_CURRENT_FILE_DIRECTORY}/../models/simple_camera.dae</model_uri>
       <model_scale>${sensor_visual_scale|1.0}</model_scale>

--- a/definitions/rgbd_camera.sensor.xml
+++ b/definitions/rgbd_camera.sensor.xml
@@ -16,6 +16,9 @@
     
     <show_3d_pointcloud>${show_3d_pointcloud|false}</show_3d_pointcloud>
 
+    <!-- Whether the GUI preview subwindow(s) for this sensor start opened (true, default) or minimized (false) -->
+    <preview_win_visible>${preview_win_visible|true}</preview_win_visible>
+
     <!-- ROS publishing options for depth image & colored pointcloud -->
     <publish_ros_depth_image>${publish_ros_depth_image|true}</publish_ros_depth_image>
     <publish_ros_colored_pointcloud>${publish_ros_colored_pointcloud|false}</publish_ros_colored_pointcloud>

--- a/modules/simulator/include/mvsim/Sensors/SensorBase.h
+++ b/modules/simulator/include/mvsim/Sensors/SensorBase.h
@@ -64,6 +64,11 @@ class SensorBase : public VisualObject, public Simulable
 
 	double sensor_period() const { return sensor_period_; }
 
+	/** Whether the sensor preview subwindow (for sensors with a GUI
+	 * image/point-cloud preview, e.g. cameras) should start opened (true,
+	 * default) or minimized (false). See XML tag "preview_win_visible". */
+	bool previewWinVisible() const { return previewWinVisible_; }
+
 	/** The vehicle this sensor is attached to */
 	Simulable& vehicle() { return vehicle_; }
 	const Simulable& vehicle() const { return vehicle_; }
@@ -95,6 +100,10 @@ class SensorBase : public VisualObject, public Simulable
 
 	/// Filled in by SensorBase::loadConfigFrom()
 	std::map<std::string, std::string> varValues_;
+
+	/** Whether the sensor GUI preview subwindow starts opened or minimized.
+	 * See previewWinVisible() */
+	bool previewWinVisible_ = true;
 
 	bool parseSensorPublish(
 		const rapidxml::xml_node<char>* node, const std::map<std::string, std::string>& varValues);

--- a/modules/simulator/include/mvsim/World.h
+++ b/modules/simulator/include/mvsim/World.h
@@ -881,7 +881,13 @@ class World : public mrpt::system::COutputLogger
 		const Simulable& veh, const std::shared_ptr<mrpt::obs::CObservationImage>& obs);
 
 	mrpt::math::TPoint2D internal_gui_on_image(
-		const std::string& label, const mrpt::img::CImage& im, int winPosX);
+		const std::string& label, const mrpt::img::CImage& im, int winPosX, bool startVisible);
+
+	/** Looks up, among veh's sensors, the one with the given sensorLabel and
+	 * returns its previewWinVisible() flag (true if not found, for backwards
+	 * compatibility). */
+	static bool internal_gui_sensor_preview_visible(
+		const Simulable& veh, const std::string& sensorLabel);
 
 	std::map<std::string, nanogui::Window*> guiObsViz_;	 //!< by sensorLabel
 

--- a/modules/simulator/src/Sensors/SensorBase.cpp
+++ b/modules/simulator/src/Sensors/SensorBase.cpp
@@ -248,6 +248,7 @@ void SensorBase::loadConfigFrom(const rapidxml::xml_node<char>* root)
 
 	TParameterDefinitions params;
 	params["sensor_period"] = TParamEntry("%lf", &sensor_period_);
+	params["preview_win_visible"] = TParamEntry("%bool", &previewWinVisible_);
 
 	// Parse XML params:
 	parse_xmlnode_children_as_param(*root, params, varValues_);

--- a/modules/simulator/src/World_gui.cpp
+++ b/modules/simulator/src/World_gui.cpp
@@ -19,6 +19,7 @@
 #include <mrpt/opengl/COpenGLScene.h>
 #include <mrpt/system/thread_name.h>
 #include <mrpt/version.h>
+#include <mvsim/VehicleBase.h>
 #include <mvsim/World.h>
 
 #include <cmath>  // cos(), sin()
@@ -1142,6 +1143,24 @@ void World::internal_gui_on_observation(
 	}
 }
 
+bool World::internal_gui_sensor_preview_visible(
+	const Simulable& veh, const std::string& sensorLabel)
+{
+	const auto* vehPtr = dynamic_cast<const VehicleBase*>(&veh);
+	if (!vehPtr)
+	{
+		return true;
+	}
+	for (const auto& s : vehPtr->getSensors())
+	{
+		if (s && s->getName() == sensorLabel)
+		{
+			return s->previewWinVisible();
+		}
+	}
+	return true;
+}
+
 void World::internal_gui_on_observation_3Dscan(
 	const Simulable& veh, const std::shared_ptr<mrpt::obs::CObservation3DRangeScan>& obs)
 {
@@ -1153,10 +1172,13 @@ void World::internal_gui_on_observation_3Dscan(
 	}
 	mrpt::math::TPoint2D rgbImageWinSize = {0, 0};
 
+	const bool startVisible = internal_gui_sensor_preview_visible(veh, obs->sensorLabel);
+
 	if (obs->hasIntensityImage)
 	{
 		rgbImageWinSize = internal_gui_on_image(
-			veh.getName() + "/"s + obs->sensorLabel + "_rgb"s, obs->intensityImage, 5);
+			veh.getName() + "/"s + obs->sensorLabel + "_rgb"s, obs->intensityImage, 5,
+			startVisible);
 	}
 	if (obs->hasRangeImage)
 	{
@@ -1167,8 +1189,8 @@ void World::internal_gui_on_observation_3Dscan(
 		imDepth.setFromMatrix(d, true /* in range [0,1] */);
 
 		internal_gui_on_image(
-			veh.getName() + "/"s + obs->sensorLabel + "_depth"s, imDepth,
-			5 + 5 + rgbImageWinSize.x);
+			veh.getName() + "/"s + obs->sensorLabel + "_depth"s, imDepth, 5 + 5 + rgbImageWinSize.x,
+			startVisible);
 	}
 }
 
@@ -1183,12 +1205,14 @@ void World::internal_gui_on_observation_image(
 	}
 	mrpt::math::TPoint2D rgbImageWinSize = {0, 0};
 
-	rgbImageWinSize =
-		internal_gui_on_image(veh.getName() + "/"s + obs->sensorLabel + "_rgb"s, obs->image, 5);
+	const bool startVisible = internal_gui_sensor_preview_visible(veh, obs->sensorLabel);
+
+	rgbImageWinSize = internal_gui_on_image(
+		veh.getName() + "/"s + obs->sensorLabel + "_rgb"s, obs->image, 5, startVisible);
 }
 
 mrpt::math::TPoint2D World::internal_gui_on_image(
-	const std::string& label, const mrpt::img::CImage& im, int winPosX)
+	const std::string& label, const mrpt::img::CImage& im, int winPosX, bool startVisible)
 {
 	mrpt::gui::MRPT2NanoguiGLCanvas* glControl;
 
@@ -1221,6 +1245,11 @@ mrpt::math::TPoint2D World::internal_gui_on_image(
 
 		glControl->scene = mrpt::opengl::COpenGLScene::Create();
 		gui_.gui_win->performLayout();
+
+		if (!startVisible)
+		{
+			gui_.gui_win->subwindowMinimize(gui_.gui_win->getSubwindowCount() - 1);
+		}
 	}
 
 	// Update from sensor data:

--- a/mvsim_tutorial/demo_camera.world.xml
+++ b/mvsim_tutorial/demo_camera.world.xml
@@ -44,9 +44,10 @@
 		</publish>
 
 		<!-- Sensors -->
-		<include file="../definitions/camera.sensor.xml" 
+		<include file="../definitions/camera.sensor.xml"
 		  sensor_x="0.6"  sensor_y="0" sensor_z="0.65"
 		  sensor_period_sec="0.10"
+		  preview_win_visible="true"
 		  />
 
 	</vehicle>


### PR DESCRIPTION
## Summary
- Add a new common sensor XML tag `<preview_win_visible>` (default `true`) controlling whether a camera/RGBD-camera GUI preview subwindow starts opened or minimized, without affecting the simulated sensor data itself.
- Default is `true`, so existing `world.xml` files without the tag behave exactly as before.
- Updated `definitions/camera.sensor.xml` and `definitions/rgbd_camera.sensor.xml` to expose `${preview_win_visible|true}`.
- Updated `mvsim_tutorial/demo_camera.world.xml` as a usage example (left explicitly `true`/visible).
- Documented the new tag in `agents.md`.

## Test plan
- [x] `make -j$(nproc) mvsim-simulator` builds cleanly
- [x] Headless run (`mvsim launch mvsim_tutorial/demo_camera.world.xml --headless`) with `preview_win_visible="true"` and `"false"` both parse and run without exceptions
- [ ] Manual GUI check that the subwindow actually starts minimized when `false` (not verifiable in this headless dev environment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Camera and RGB-D camera previews can now start opened or minimized.
  * Added the `preview_win_visible` setting, which defaults to opened (`true`).
  * Preview visibility can be configured independently for each sensor.

* **Documentation**
  * Documented the new preview visibility option and its effect on GUI windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->