### PR TITLE
feat(ros): use simulation time for stamps and publish /clock

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -128,6 +128,8 @@ Key headers in `modules/comms/include/mvsim/Comms/`:
 - `mvsim_node.cpp` — `MvSimNode` class wrapping `World`, publishing sensor observations as ROS topics, subscribing to `cmd_vel`, advertising TF transforms and ROS 2 parameters.
 - `mvsim_node_src/include/` — node header
 
+**Simulation time:** the node is the ROS time source. It publishes `/clock` and stamps every header with *simulation* time (`World::get_simul_timestamp()`); sensor messages use the observation's own `obs.timestamp` so stamps are immune to publisher-thread latency. `myNow()`/`myNowSec()` return sim time (wall-clock fallback before the first step). Downstream nodes should set `use_sim_time:=true`; the node itself runs with `use_sim_time:=false` (only warns if set true).
+
 ---
 
 ## CLI tool (`mvsim-cli/`)

--- a/docs/mvsim_node.rst
+++ b/docs/mvsim_node.rst
@@ -160,3 +160,28 @@ You can use this code to bootstrap your own launch files:
 
 
 |
+
+Simulation time and the ``/clock`` topic
+-----------------------------------------
+
+The ``mvsim_node`` acts as the ROS **time source** for the whole system:
+
+* It publishes the global ``/clock`` topic (``rosgraph_msgs/Clock``) with the
+  current simulation time (the wall-clock time at simulation start plus the
+  elapsed simulated seconds).
+* Every message header it publishes (``/odom``, ``/base_pose_ground_truth``,
+  ``/tf``, and all sensor topics) is stamped with that same **simulation time**.
+  Sensor messages in particular are stamped with the exact instant the
+  observation was generated inside the simulation, so their timestamps are
+  unaffected by any latency in the asynchronous ROS publisher threads.
+
+Because header stamps track *simulation* time rather than wall-clock time, they
+stay coherent even when the simulation cannot keep up with real time (real-time
+factor below 1.0 due to heavy sensor/GUI load).
+
+.. note::
+   Run your **downstream** nodes with ``use_sim_time:=true`` so they consume
+   ``/clock``. The ``mvsim_node`` itself *drives* the clock and normally runs
+   with ``use_sim_time:=false``; setting ``use_sim_time:=true`` on the mvsim
+   node is discouraged (a warning is printed) since it would make the node
+   depend on the very clock it publishes.

--- a/docs/vehicles.rst
+++ b/docs/vehicles.rst
@@ -794,6 +794,20 @@ This creates CSV files:
 
 MVSim publishes the following ROS 2 topics for each vehicle. Topic names are prefixed with the vehicle name when multiple vehicles exist in the simulation, or published directly when only one vehicle is present.
 
+.. note::
+   **Simulation time.** MVSim is the ROS *time source*: it publishes the global
+   ``/clock`` topic and stamps every outgoing message header with **simulation
+   time** (the wall-clock time at simulation start plus the elapsed simulated
+   seconds). This keeps all stamps coherent regardless of the real-time factor
+   or transient CPU load. Run your downstream nodes with ``use_sim_time:=true``
+   so they consume ``/clock``; the ``mvsim_node`` itself drives the clock and
+   normally runs with ``use_sim_time:=false``.
+
+Global Topics
+~~~~~~~~~~~~~
+
+* ``/clock`` (rosgraph_msgs/Clock) - Simulation time, for nodes running with ``use_sim_time:=true``
+
 Standard Vehicle Topics
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/modules/simulator/include/mvsim/World.h
+++ b/modules/simulator/include/mvsim/World.h
@@ -47,6 +47,7 @@
 #endif
 
 #include <any>
+#include <atomic>
 #include <functional>
 #include <list>
 #include <map>
@@ -195,6 +196,20 @@ class World : public mrpt::system::COutputLogger
 		ASSERT_(simul_start_wallclock_time_.has_value());
 		return mrpt::Clock::fromDouble(simulTime_ + simul_start_wallclock_time_.value());
 	}
+
+	/** Returns true once the simulation has an established wall-clock time
+	 *  origin (i.e. run_simulation() has been called at least once), so that
+	 *  get_simul_timestamp() can be safely queried. */
+	bool has_simul_timestamp() const
+	{
+		auto lck = mrpt::lockHelper(simul_time_mtx_);
+		return simul_start_wallclock_time_.has_value();
+	}
+
+	/** Achieved real-time factor: smoothed ratio of simulated time advanced to
+	 *  wall-clock time elapsed. 1.0 means real time; below 1.0 means the
+	 *  simulation is running slower than real time. \sa run_simulation() */
+	double get_realtime_factor_achieved() const { return achievedRealtimeFactor_.load(); }
 
 	/// Simulation fixed-time interval for numerical integration
 	double get_simul_timestep() const;
@@ -558,6 +573,12 @@ class World : public mrpt::system::COutputLogger
 	double simulTime_ = 0;
 	std::optional<double> simul_start_wallclock_time_;
 	std::mutex simul_time_mtx_;
+
+	/** Achieved real-time factor (simulated seconds advanced per wall-clock
+	 * second), exponentially smoothed. 1.0 = real time; below 1.0 = running
+	 * slower than real time (e.g. CPU-bound). Updated by run_simulation(). */
+	std::atomic<double> achievedRealtimeFactor_{1.0};
+	std::optional<double> lastRunSimulWallclock_;
 
 	/** Path from which to take relative directories. */
 	std::string basePath_{"."};

--- a/modules/simulator/src/World_gui.cpp
+++ b/modules/simulator/src/World_gui.cpp
@@ -1029,6 +1029,12 @@ void World::internalUpdate3DSceneObjects(
 		guiMsgLinesMtx_.unlock();
 
 		int nextStatusLine = 0;
+
+		// Achieved real-time simulation speed (1.0 = real time):
+		gui_.lbStatuses.at(nextStatusLine++)
+			->setCaption(
+				mrpt::format("Sim speed: %.03fx real time", get_realtime_factor_achieved()));
+
 		if (!msg_lines.empty())
 		{
 			// split lines:

--- a/modules/simulator/src/World_simul.cpp
+++ b/modules/simulator/src/World_simul.cpp
@@ -36,6 +36,22 @@ void World::run_simulation(double dt)
 
 	timlogger_.registerUserMeasure("run_simulation.dt", dt);
 
+	// Track the achieved real-time factor: simulated time advanced (dt) per
+	// wall-clock second elapsed between successive run_simulation() calls,
+	// exponentially smoothed. Dips below 1.0 when the machine cannot keep up.
+	if (lastRunSimulWallclock_.has_value())
+	{
+		const double wallGap = t0 - lastRunSimulWallclock_.value();
+		if (wallGap > 1e-6)
+		{
+			const double instFactor = dt / wallGap;
+			const double alpha = 0.1;  // EMA smoothing factor
+			achievedRealtimeFactor_ =
+				(1.0 - alpha) * achievedRealtimeFactor_.load() + alpha * instFactor;
+		}
+	}
+	lastRunSimulWallclock_ = t0;
+
 	const double simulTimestep = get_simul_timestep();
 
 	// sanity checks:

--- a/mvsim_node_src/include/mvsim/mvsim_node_core.h
+++ b/mvsim_node_src/include/mvsim/mvsim_node_core.h
@@ -62,6 +62,7 @@ using Msg_Bool = std_msgs::Bool;
 using Msg_TFMessage = tf2_msgs::TFMessage;
 using Msg_MarkerArray = visualization_msgs::MarkerArray;
 using Msg_CameraInfo = sensor_msgs::CameraInfo;
+using Msg_Clock = rosgraph_msgs::Clock;
 #else
 #include <geometry_msgs/msg/polygon.hpp>
 #include <geometry_msgs/msg/pose_array.hpp>
@@ -73,6 +74,7 @@ using Msg_CameraInfo = sensor_msgs::CameraInfo;
 #include <rclcpp/clock.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/time_source.hpp>
+#include <rosgraph_msgs/msg/clock.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include <std_msgs/msg/float64.hpp>
@@ -99,6 +101,7 @@ using Msg_Float64 = std_msgs::msg::Float64;
 using Msg_TFMessage = tf2_msgs::msg::TFMessage;
 using Msg_MarkerArray = visualization_msgs::msg::MarkerArray;
 using Msg_CameraInfo = sensor_msgs::msg::CameraInfo;
+using Msg_Clock = rosgraph_msgs::msg::Clock;
 #endif
 
 namespace mvsim_node
@@ -201,10 +204,14 @@ class MVSimNode
 
 	// === ROS Publishers ====
 #if PACKAGE_ROS_VERSION == 1
-	// mvsim_node::shared_ptr<ros::Publisher> pub_clock_;
+	/// Publisher of the "/clock" topic (simulation time source).
+	mvsim_node::shared_ptr<ros::Publisher> pub_clock_;
 #else
 	rclcpp::TimeSource ts_{n_};
 	rclcpp::Clock::SharedPtr clock_;
+
+	/// Publisher of the "/clock" topic (simulation time source).
+	rclcpp::Publisher<Msg_Clock>::SharedPtr pub_clock_;
 #endif
 
 	struct WorldPubs
@@ -304,10 +311,6 @@ class MVSimNode
 	void onROSMsgCmdVel(Msg_Twist_CSPtr cmd, mvsim::VehicleBase* veh);
 	// === End ROS Hooks====
 
-#if PACKAGE_ROS_VERSION == 1
-	// rosgraph_msgs::Clock clockMsg_;
-#endif
-	// ros_Time sim_time_;	 //!< Current simulation time
 	ros_Time base_last_cmd_;  //!< received a vel_cmd (for watchdog)
 	ros_Duration base_watchdog_timeout_ = ros_Duration(1, 0);
 

--- a/mvsim_node_src/mvsim_node.cpp
+++ b/mvsim_node_src/mvsim_node.cpp
@@ -154,7 +154,7 @@ MVSimNode::MVSimNode(rclcpp::Node::SharedPtr& n)
 	// outgoing messages with simulation time. The mvsim node itself therefore
 	// normally runs with use_sim_time:=false (it drives the clock); it is the
 	// downstream nodes that should set use_sim_time:=true.
-	if (true == localn_.param("use_sim_time", false))
+	if (true == n_.param("use_sim_time", false))
 	{
 		ROS_WARN(
 			"use_sim_time=true was set on the mvsim node itself. mvsim is the "
@@ -1615,7 +1615,7 @@ void MVSimNode::internalOn(
 
 	// Stamp with the observation's own simulation timestamp (see note in the
 	// 2D LiDAR handler).
-	const auto now = mrpt2ros::toROS(obs.timestamp);
+	const auto obsStamp = mrpt2ros::toROS(obs.timestamp);
 
 	// ----------------------------------------------------------------
 	// RGB IMAGE
@@ -1630,14 +1630,14 @@ void MVSimNode::internalOn(
 		tfStmp.transform = tf2::toMsg(transform);
 		tfStmp.header.frame_id = "base_link";
 		tfStmp.child_frame_id = lbImage;
-		tfStmp.header.stamp = now;
+		tfStmp.header.stamp = obsStamp;
 
 		Msg_TFMessage tfMsg;
 		tfMsg.transforms.push_back(tfStmp);
 		pubs.pub_tf->publish(tfMsg);
 
 		Msg_Header msg_header;
-		msg_header.stamp = now;
+		msg_header.stamp = obsStamp;
 		msg_header.frame_id = lbImage;
 
 		// Send observation:
@@ -1669,7 +1669,7 @@ void MVSimNode::internalOn(
 			tfStmp.transform = tf2::toMsg(transform);
 			tfStmp.header.frame_id = "base_link";
 			tfStmp.child_frame_id = obs.sensorLabel + "_depth";
-			tfStmp.header.stamp = now;
+			tfStmp.header.stamp = obsStamp;
 
 			Msg_TFMessage tfMsg;
 			tfMsg.transforms.push_back(tfStmp);
@@ -1677,7 +1677,7 @@ void MVSimNode::internalOn(
 		}
 
 		Msg_Header msg_header;
-		msg_header.stamp = now;
+		msg_header.stamp = obsStamp;
 		msg_header.frame_id = obs.sensorLabel + "_depth";
 
 		// Build 16UC1 depth image from rangeImage (uint16_t matrix).
@@ -1727,7 +1727,7 @@ void MVSimNode::internalOn(
 		tfStmp.transform = tf2::toMsg(transform);
 		tfStmp.header.frame_id = "base_link";
 		tfStmp.child_frame_id = lbPoints;
-		tfStmp.header.stamp = now;
+		tfStmp.header.stamp = obsStamp;
 
 		Msg_TFMessage tfMsg;
 		tfMsg.transforms.push_back(tfStmp);
@@ -1737,7 +1737,7 @@ void MVSimNode::internalOn(
 		{
 			Msg_PointCloud2 msg_pts;
 			Msg_Header msg_header;
-			msg_header.stamp = now;
+			msg_header.stamp = obsStamp;
 			msg_header.frame_id = lbPoints;
 
 			mrpt::obs::T3DPointsProjectionParams pp;
@@ -1795,7 +1795,7 @@ void MVSimNode::internalOn(
 
 	// Stamp with the observation's own simulation timestamp (see note in the
 	// 2D LiDAR handler).
-	const auto now = mrpt2ros::toROS(obs.timestamp);
+	const auto obsStamp = mrpt2ros::toROS(obs.timestamp);
 
 	// POINTS
 	// --------
@@ -1808,7 +1808,7 @@ void MVSimNode::internalOn(
 	tfStmp.transform = tf2::toMsg(transform);
 	tfStmp.header.frame_id = "base_link";
 	tfStmp.child_frame_id = lbPoints;
-	tfStmp.header.stamp = now;
+	tfStmp.header.stamp = obsStamp;
 
 	Msg_TFMessage tfMsg;
 	tfMsg.transforms.push_back(tfStmp);
@@ -1819,7 +1819,7 @@ void MVSimNode::internalOn(
 		// Convert observation MRPT -> ROS
 		auto msg_pts = mvsim_node::make_shared<Msg_PointCloud2>();
 		Msg_Header msg_header;
-		msg_header.stamp = now;
+		msg_header.stamp = obsStamp;
 		msg_header.frame_id = lbPoints;
 
 #if MRPT_VERSION < 0x020f00	 // 2.15.0 support legacy classes

--- a/mvsim_node_src/mvsim_node.cpp
+++ b/mvsim_node_src/mvsim_node.cpp
@@ -35,6 +35,7 @@
 #include <mrpt/ros1bridge/map.h>
 #include <mrpt/ros1bridge/point_cloud2.h>
 #include <mrpt/ros1bridge/pose.h>
+#include <mrpt/ros1bridge/time.h>
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/Imu.h>
 #include <sensor_msgs/LaserScan.h>
@@ -68,6 +69,7 @@ using Msg_Marker = visualization_msgs::Marker;
 #include <mrpt/ros2bridge/map.h>
 #include <mrpt/ros2bridge/point_cloud2.h>
 #include <mrpt/ros2bridge/pose.h>
+#include <mrpt/ros2bridge/time.h>
 
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/imu.hpp>
@@ -148,12 +150,16 @@ MVSimNode::MVSimNode(rclcpp::Node::SharedPtr& n)
 		"force_publish_vehicle_namespace", force_publish_vehicle_namespace_,
 		force_publish_vehicle_namespace_);
 
-	// JLBC: At present, mvsim does not use sim_time for neither ROS 1 nor
-	// ROS 2.
-	// n_.setParam("use_sim_time", false);
+	// mvsim is the ROS *time source*: it publishes "/clock" and stamps all
+	// outgoing messages with simulation time. The mvsim node itself therefore
+	// normally runs with use_sim_time:=false (it drives the clock); it is the
+	// downstream nodes that should set use_sim_time:=true.
 	if (true == localn_.param("use_sim_time", false))
 	{
-		THROW_EXCEPTION("At present, MVSIM can only work with use_sim_time=false");
+		ROS_WARN(
+			"use_sim_time=true was set on the mvsim node itself. mvsim is the "
+			"/clock time source and normally runs with use_sim_time:=false; set "
+			"use_sim_time:=true on downstream nodes instead.");
 	}
 #else
 	clock_ = n_->get_clock();
@@ -196,13 +202,21 @@ MVSimNode::MVSimNode(rclcpp::Node::SharedPtr& n)
 
 	publish_log_topics_ = n_->declare_parameter<bool>("publish_log_topics", publish_log_topics_);
 
-	// n_->declare_parameter("use_sim_time"); // already declared error?
+	// mvsim is the ROS *time source*: it publishes "/clock" and stamps all
+	// outgoing messages with simulation time. The mvsim node itself therefore
+	// normally runs with use_sim_time:=false (it drives the clock); it is the
+	// downstream nodes that should set use_sim_time:=true.
 	{
 		bool use_sim_time = false;
 		n_->get_parameter_or("use_sim_time", use_sim_time, false);
 		if (use_sim_time)
 		{
-			THROW_EXCEPTION("At present, MVSIM can only work with use_sim_time=false");
+			RCLCPP_WARN(
+				n_->get_logger(),
+				"use_sim_time=true was set on the mvsim node itself. mvsim is "
+				"the /clock time source and normally runs with "
+				"use_sim_time:=false; set use_sim_time:=true on downstream nodes "
+				"instead.");
 		}
 	}
 #endif
@@ -213,16 +227,15 @@ MVSimNode::MVSimNode(rclcpp::Node::SharedPtr& n)
 
 	// Init ROS publishers:
 #if PACKAGE_ROS_VERSION == 1
-	// pub_clock_ =
-	// mvsim_node::make_shared<ros::Publisher>(n_.advertise<rosgraph_msgs::Clock>("/clock",
-	// 10));
+	pub_clock_ = mvsim_node::make_shared<ros::Publisher>(
+		n_.advertise<Msg_Clock>("/clock", publisher_history_len_));
+#else
+	pub_clock_ = n_->create_publisher<Msg_Clock>("/clock", rclcpp::ClockQoS());
 #endif
 
 #if PACKAGE_ROS_VERSION == 1
-	// sim_time_.fromSec(0.0);
 	base_last_cmd_.fromSec(0.0);
 #else
-	// sim_time_ = rclcpp::Time(0);
 	base_last_cmd_ = rclcpp::Time(0);
 #endif
 
@@ -618,6 +631,16 @@ void MVSimNode::notifyROSWorldIsUpdated()
 
 ros_Time MVSimNode::myNow() const
 {
+	// mvsim is the ROS time authority: header stamps use *simulation* time
+	// (wall-clock at sim start + elapsed simulated seconds) so they stay
+	// coherent regardless of the real-time factor or transient CPU load, and
+	// match the "/clock" topic consumed by downstream nodes running with
+	// use_sim_time:=true. Fall back to wall-clock only before the first
+	// simulation step, when no sim timestamp exists yet.
+	if (mvsim_world_ && mvsim_world_->has_simul_timestamp())
+	{
+		return mrpt2ros::toROS(mvsim_world_->get_simul_timestamp());
+	}
 #if PACKAGE_ROS_VERSION == 1
 	return ros::Time::now();
 #else
@@ -627,6 +650,10 @@ ros_Time MVSimNode::myNow() const
 
 double MVSimNode::myNowSec() const
 {
+	if (mvsim_world_ && mvsim_world_->has_simul_timestamp())
+	{
+		return mrpt::Clock::toDouble(mvsim_world_->get_simul_timestamp());
+	}
 #if PACKAGE_ROS_VERSION == 1
 	return ros::Time::now().toSec();
 #else
@@ -872,16 +899,16 @@ void MVSimNode::spinNotifyROS()
 	{
 		return;
 	}
-	// Get current simulation time (for messages) and publish "/clock"
+	// Publish "/clock" so downstream nodes can run with use_sim_time:=true.
+	// mvsim is the simulation time authority; all header stamps below use the
+	// same simulation time base (see myNow()).
 	// ----------------------------------------------------------------
-#if PACKAGE_ROS_VERSION == 1
-	// sim_time_.fromSec(mvsim_world_->get_simul_time());
-	// clockMsg_.clock = sim_time_;
-	// pub_clock_->publish(clockMsg_);
-#else
-	// sim_time_ = myNow();
-	// MRPT_TODO("Publish /clock for ROS2 too?");
-#endif
+	if (pub_clock_ && mvsim_world_->has_simul_timestamp())
+	{
+		Msg_Clock clockMsg;
+		clockMsg.clock = mrpt2ros::toROS(mvsim_world_->get_simul_timestamp());
+		pub_clock_->publish(clockMsg);
+	}
 
 	// Publish all TFs for each vehicle:
 	// ---------------------------------------------------------------------
@@ -1211,6 +1238,11 @@ void MVSimNode::internalOn(
 	}
 	lck.unlock();
 
+	// Stamp with the observation's own simulation timestamp (set when the
+	// sensor was sampled), not "now", so the stamp is unaffected by any latency
+	// in the asynchronous publisher worker thread.
+	const auto obsStamp = mrpt2ros::toROS(obs.timestamp);
+
 	// Send TF:
 	mrpt::poses::CPose3D sensorPose = obs.sensorPose;
 	auto transform = mrpt2ros::toROS_tfTransform(sensorPose);
@@ -1219,7 +1251,7 @@ void MVSimNode::internalOn(
 	tfStmp.transform = tf2::toMsg(transform);
 	tfStmp.header.frame_id = "base_link";
 	tfStmp.child_frame_id = obs.sensorLabel;
-	tfStmp.header.stamp = myNow();
+	tfStmp.header.stamp = obsStamp;
 
 	Msg_TFMessage tfMsg;
 	tfMsg.transforms.push_back(tfStmp);
@@ -1230,8 +1262,7 @@ void MVSimNode::internalOn(
 		// Convert observation MRPT -> ROS
 		Msg_Pose msg_pose_laser;
 		Msg_LaserScan msg_laser;
-		// Force usage of simulation time:
-		msg_laser.header.stamp = myNow();
+		msg_laser.header.stamp = obsStamp;
 		msg_laser.header.frame_id = obs.sensorLabel;
 		mrpt2ros::toROS(obs, msg_laser, msg_pose_laser);
 		pub->publish(mvsim_node::make_shared<Msg_LaserScan>(msg_laser));
@@ -1259,6 +1290,10 @@ void MVSimNode::internalOn(const mvsim::VehicleBase& veh, const mrpt::obs::CObse
 	}
 	lck.unlock();
 
+	// Stamp with the observation's own simulation timestamp (see note in the
+	// 2D LiDAR handler).
+	const auto obsStamp = mrpt2ros::toROS(obs.timestamp);
+
 	// Send TF:
 	mrpt::poses::CPose3D sensorPose = obs.sensorPose;
 	auto transform = mrpt2ros::toROS_tfTransform(sensorPose);
@@ -1267,7 +1302,7 @@ void MVSimNode::internalOn(const mvsim::VehicleBase& veh, const mrpt::obs::CObse
 	tfStmp.transform = tf2::toMsg(transform);
 	tfStmp.header.frame_id = "base_link";
 	tfStmp.child_frame_id = obs.sensorLabel;
-	tfStmp.header.stamp = myNow();
+	tfStmp.header.stamp = obsStamp;
 
 	Msg_TFMessage tfMsg;
 	tfMsg.transforms.push_back(tfStmp);
@@ -1278,8 +1313,7 @@ void MVSimNode::internalOn(const mvsim::VehicleBase& veh, const mrpt::obs::CObse
 		// Convert observation MRPT -> ROS
 		Msg_Imu msg_imu;
 		Msg_Header msg_header;
-		// Force usage of simulation time:
-		msg_header.stamp = myNow();
+		msg_header.stamp = obsStamp;
 		msg_header.frame_id = obs.sensorLabel;
 		mrpt2ros::toROS(obs, msg_header, msg_imu);
 		pub->publish(mvsim_node::make_shared<Msg_Imu>(msg_imu));
@@ -1313,6 +1347,10 @@ void MVSimNode::internalOn(const mvsim::VehicleBase& veh, const mrpt::obs::CObse
 	}
 	lck.unlock();
 
+	// Stamp with the observation's own simulation timestamp (see note in the
+	// 2D LiDAR handler).
+	const auto obsStamp = mrpt2ros::toROS(obs.timestamp);
+
 	// Send TF:
 	mrpt::poses::CPose3D sensorPose = obs.sensorPose;
 	auto transform = mrpt2ros::toROS_tfTransform(sensorPose);
@@ -1321,7 +1359,7 @@ void MVSimNode::internalOn(const mvsim::VehicleBase& veh, const mrpt::obs::CObse
 	tfStmp.transform = tf2::toMsg(transform);
 	tfStmp.header.frame_id = "base_link";
 	tfStmp.child_frame_id = obs.sensorLabel;
-	tfStmp.header.stamp = myNow();
+	tfStmp.header.stamp = obsStamp;
 
 	Msg_TFMessage tfMsg;
 	tfMsg.transforms.push_back(tfStmp);
@@ -1339,7 +1377,7 @@ void MVSimNode::internalOn(const mvsim::VehicleBase& veh, const mrpt::obs::CObse
 		// though the simulated fix quality (mrpt::obs::gnss::Message_NMEA_GGA
 		// ::fields::fix_quality) was perfectly valid.
 		Msg_Header msg_header;
-		msg_header.stamp = myNow();
+		msg_header.stamp = obsStamp;
 		msg_header.frame_id = obs.sensorLabel;
 
 		auto msg = mvsim_node::make_shared<Msg_GPS>();
@@ -1468,6 +1506,10 @@ void MVSimNode::internalOn(const mvsim::VehicleBase& veh, const mrpt::obs::CObse
 	}
 	lck.unlock();
 
+	// Stamp with the observation's own simulation timestamp (see note in the
+	// 2D LiDAR handler).
+	const auto obsStamp = mrpt2ros::toROS(obs.timestamp);
+
 	// Send TF:
 	mrpt::poses::CPose3D sensorPose;
 	obs.getSensorPose(sensorPose);
@@ -1477,7 +1519,7 @@ void MVSimNode::internalOn(const mvsim::VehicleBase& veh, const mrpt::obs::CObse
 	tfStmp.transform = tf2::toMsg(transform);
 	tfStmp.header.frame_id = "base_link";
 	tfStmp.child_frame_id = obs.sensorLabel;
-	tfStmp.header.stamp = myNow();
+	tfStmp.header.stamp = obsStamp;
 
 	Msg_TFMessage tfMsg;
 	tfMsg.transforms.push_back(tfStmp);
@@ -1485,7 +1527,7 @@ void MVSimNode::internalOn(const mvsim::VehicleBase& veh, const mrpt::obs::CObse
 
 	// Send observation:
 	Msg_Header msg_header;
-	msg_header.stamp = myNow();
+	msg_header.stamp = obsStamp;
 	msg_header.frame_id = obs.sensorLabel;
 
 	{
@@ -1571,7 +1613,9 @@ void MVSimNode::internalOn(
 
 	lck.unlock();
 
-	const auto now = myNow();
+	// Stamp with the observation's own simulation timestamp (see note in the
+	// 2D LiDAR handler).
+	const auto now = mrpt2ros::toROS(obs.timestamp);
 
 	// ----------------------------------------------------------------
 	// RGB IMAGE
@@ -1749,7 +1793,9 @@ void MVSimNode::internalOn(
 	}
 	lck.unlock();
 
-	const auto now = myNow();
+	// Stamp with the observation's own simulation timestamp (see note in the
+	// 2D LiDAR handler).
+	const auto now = mrpt2ros::toROS(obs.timestamp);
 
 	// POINTS
 	// --------


### PR DESCRIPTION
## Motivation

Investigating the report that header stamps on `/odom`, `/imu` and
`/base_pose_ground_truth` drift +1.7–2.9% behind a bag's wall-clock
recording time under heavy LiDAR/GICP load, the root cause turned out to
be architectural: **mvsim stamped every ROS header with wall-clock time**
(`clock_->now()`, with `use_sim_time` hard-disabled), not simulation
time — the `// Force usage of simulation time` comments were stale. So
stamps could not track sim time, and under load the two publish paths
(synchronous odom/GT/TF vs. the asynchronous sensor worker pool) skewed
apart.

## What this does (Option A: make mvsim a proper time source)

- **Publish `/clock`** (`rosgraph_msgs/Clock`) from `World::get_simul_timestamp()`
  (wall-clock at sim start + elapsed simulated seconds).
- **`myNow()` / `myNowSec()` return simulation time** (wall-clock fallback
  before the first step, guarded by the new `World::has_simul_timestamp()`).
- **Odom / ground-truth / TF** are stamped with sim time; **sensor
  messages** are stamped with the observation's own `obs.timestamp`
  (exact generation instant), making them immune to publisher-thread
  latency — this directly fixes the observed drift/bursts.
- **`use_sim_time:=true` on the mvsim node** is no longer a hard error but a
  warning: mvsim drives the clock and normally runs with
  `use_sim_time:=false`; downstream nodes should set `use_sim_time:=true`.

## GUI

Exposes an **achieved real-time factor** (smoothed simulated/wall-clock
ratio) via `World::get_realtime_factor_achieved()`, shown in the status
overlay below the CPU-usage line: `Sim speed: 0.98x real time`.

## Docs

`docs/mvsim_node.rst`, `docs/vehicles.rst` (new `/clock` global topic +
simulation-time note) and `agents.md` updated.

## Testing

- `colcon build --packages-select mvsim` (ROS 2) passes.
- clang-format-14 applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/clock` publishing using simulation time, with message headers stamped consistently.
  * Exposed achieved real-time factor (“Sim speed”) in the simulator GUI.
  * Added `has_simul_timestamp()` and achieved real-time factor accessors to the world runtime.
* **Bug Fixes**
  * Sensor/TF/message headers now use each observation’s own timestamp to avoid publisher-thread latency effects.
* **Documentation**
  * Documented MVSim simulation-time behavior and guidance for downstream nodes to use `use_sim_time:=true` (while discouraging enabling it on the simulator node).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->