### PR TITLE
feat(ros): add disable_sim_time_clock param to opt out of sim clock

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -20,6 +20,8 @@ jobs:
         # Github Actions requires a single row to be added to the build matrix.
         # See https://help.github.com/en/articles/workflow-syntax-for-github-actions.
         name: [
+          ubuntu-26.04-clang-ppa-mrpt,
+          ubuntu-26.04-gcc-ppa-mrpt,
           ubuntu-24.04-clang-ppa-mrpt,
           ubuntu-24.04-gcc-ppa-mrpt,
           ubuntu-22.04-gcc-ppa-mrpt,
@@ -28,6 +30,16 @@ jobs:
 
         build_type: [ Release ]
         include:
+          - name: ubuntu-26.04-clang-ppa-mrpt
+            os: ubuntu-26.04
+            compiler: clang
+            install_mrpt_ppa: ON
+
+          - name: ubuntu-26.04-gcc-ppa-mrpt
+            os: ubuntu-26.04
+            compiler: gcc
+            install_mrpt_ppa: ON
+
           - name: ubuntu-24.04-clang-ppa-mrpt
             os: ubuntu-24.04
             compiler: clang

--- a/agents.md
+++ b/agents.md
@@ -128,7 +128,7 @@ Key headers in `modules/comms/include/mvsim/Comms/`:
 - `mvsim_node.cpp` — `MvSimNode` class wrapping `World`, publishing sensor observations as ROS topics, subscribing to `cmd_vel`, advertising TF transforms and ROS 2 parameters.
 - `mvsim_node_src/include/` — node header
 
-**Simulation time:** the node is the ROS time source. It publishes `/clock` and stamps every header with *simulation* time (`World::get_simul_timestamp()`); sensor messages use the observation's own `obs.timestamp` so stamps are immune to publisher-thread latency. `myNow()`/`myNowSec()` return sim time (wall-clock fallback before the first step). Downstream nodes should set `use_sim_time:=true`; the node itself runs with `use_sim_time:=false` (only warns if set true).
+**Simulation time:** the node is the ROS time source. It publishes `/clock` and stamps every header with *simulation* time (`World::get_simul_timestamp()`); sensor messages use the observation's own `obs.timestamp` so stamps are immune to publisher-thread latency. `myNow()`/`myNowSec()` return sim time (wall-clock fallback before the first step). Downstream nodes should set `use_sim_time:=true`; the node itself runs with `use_sim_time:=false` (only warns if set true). The `disable_sim_time_clock` parameter (default `false`) opts out of all of the above: no `/clock` publication, and every header stamp (via `myNow()`/`myObsStamp()`) uses wall-clock time instead, matching pre-simulation-clock behavior.
 
 ---
 

--- a/docs/mvsim_node.rst
+++ b/docs/mvsim_node.rst
@@ -67,6 +67,12 @@ All these parameters apply to both, ROS 1 and ROS 2 launch files above:
          Use vehicle name namespace even if there is only one vehicle
          (default: 'False')
 
+      'disable_sim_time_clock':
+         Do not use the internal simulation clock: do not publish '/clock' and
+         stamp all messages with wall-clock time instead, as done before
+         simulation time support was added
+         (default: 'False')
+
       'use_rviz':
          Whether to launch RViz2
          (default: 'True')
@@ -94,6 +100,7 @@ You can use this code to bootstrap your own launch files:
                <arg name="do_fake_localization" default="True" />
                <arg name="publish_tf_odom2baselink" default="True" />
                <arg name="force_publish_vehicle_namespace" default="False" />
+               <arg name="disable_sim_time_clock" default="False" />
                <arg name="use_rviz" default="True" />
                <arg name="rviz_config_file" default="$(find mvsim)/mvsim_tutorial/demo_depth_camera.rviz" />
 
@@ -104,6 +111,7 @@ You can use this code to bootstrap your own launch files:
                   <arg name="do_fake_localization" value="$(arg do_fake_localization)" />
                   <arg name="publish_tf_odom2baselink" value="$(arg publish_tf_odom2baselink)" />
                   <arg name="force_publish_vehicle_namespace" value="$(arg force_publish_vehicle_namespace)" />
+                  <arg name="disable_sim_time_clock" value="$(arg disable_sim_time_clock)" />
                   <arg name="use_rviz" value="$(arg use_rviz)" />
                   <arg name="rviz_config_file" value="$(arg rviz_config_file)" />
                </include>
@@ -134,6 +142,7 @@ You can use this code to bootstrap your own launch files:
                do_fake_localization = 'True'
                publish_tf_odom2baselink = 'True'
                force_publish_vehicle_namespace = 'False'
+               disable_sim_time_clock = 'False'
                use_rviz = 'True'
 
 
@@ -151,6 +160,7 @@ You can use this code to bootstrap your own launch files:
                         'do_fake_localization': do_fake_localization,
                         'publish_tf_odom2baselink': publish_tf_odom2baselink,
                         'force_publish_vehicle_namespace': force_publish_vehicle_namespace,
+                        'disable_sim_time_clock': disable_sim_time_clock,
                         'use_rviz': use_rviz,
                         'rviz_config_file': rviz_config_file
                   }.items()
@@ -185,3 +195,19 @@ factor below 1.0 due to heavy sensor/GUI load).
    with ``use_sim_time:=false``; setting ``use_sim_time:=true`` on the mvsim
    node is discouraged (a warning is printed) since it would make the node
    depend on the very clock it publishes.
+
+Disabling the simulation clock
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you prefer the previous behavior, set the ``disable_sim_time_clock``
+parameter (ROS launch argument) to ``true``. In that case:
+
+* ``mvsim_node`` does not publish ``/clock``.
+* All header stamps, including sensor observations, use plain wall-clock time
+  (as reported by the ROS clock), regardless of the real-time factor.
+
+.. code-block:: bash
+
+   ros2 launch mvsim launch_world.launch.py \
+     world_file:=/path/to/your/my.world.xml \
+     disable_sim_time_clock:=True

--- a/docs/vehicles.rst
+++ b/docs/vehicles.rst
@@ -801,7 +801,9 @@ MVSim publishes the following ROS 2 topics for each vehicle. Topic names are pre
    seconds). This keeps all stamps coherent regardless of the real-time factor
    or transient CPU load. Run your downstream nodes with ``use_sim_time:=true``
    so they consume ``/clock``; the ``mvsim_node`` itself drives the clock and
-   normally runs with ``use_sim_time:=false``.
+   normally runs with ``use_sim_time:=false``. Set the ``disable_sim_time_clock``
+   parameter to ``true`` to opt out and revert to plain wall-clock stamps (no
+   ``/clock`` publication), as done before simulation time support was added.
 
 Global Topics
 ~~~~~~~~~~~~~

--- a/launch/launch_world.launch
+++ b/launch/launch_world.launch
@@ -8,6 +8,7 @@
     <arg name="do_fake_localization" default="True" />
     <arg name="publish_tf_odom2baselink" default="True" />
     <arg name="force_publish_vehicle_namespace" default="False" />
+    <arg name="disable_sim_time_clock" default="False" />
     <arg name="use_rviz" default="True" />
     <arg name="rviz_config_file" default="$(find mvsim)/mvsim_tutorial/demo_depth_camera.rviz" />
 
@@ -18,6 +19,7 @@
         <param name="do_fake_localization" value="$(arg do_fake_localization)"/>
         <param name="publish_tf_odom2baselink" value="$(arg publish_tf_odom2baselink)"/>
         <param name="force_publish_vehicle_namespace" value="$(arg force_publish_vehicle_namespace)"/>
+        <param name="disable_sim_time_clock" value="$(arg disable_sim_time_clock)"/>
     </node>
 
     <!-- RViz Node (conditional launch based on use_rviz argument) -->

--- a/launch/launch_world.launch.py
+++ b/launch/launch_world.launch.py
@@ -33,6 +33,12 @@ def generate_launch_description():
         description='Publish every CSV-logger column as a std_msgs/Float64 topic per vehicle. '
                     'High-rate, disabled by default.')
 
+    disable_sim_time_clock_arg = DeclareLaunchArgument(
+        "disable_sim_time_clock", default_value='False',
+        description='Do not use mvsim internal simulation clock: do not publish "/clock" and '
+                    'stamp all messages with wall-clock time instead, as done before simulation '
+                    'time support was added.')
+
     use_rviz_arg = DeclareLaunchArgument(
         'use_rviz', default_value='True',
         description='Whether to launch RViz2'
@@ -56,6 +62,7 @@ def generate_launch_description():
                 "publish_tf_odom2baselink": LaunchConfiguration('publish_tf_odom2baselink'),
                 "force_publish_vehicle_namespace": LaunchConfiguration('force_publish_vehicle_namespace'),
                 "publish_log_topics": LaunchConfiguration('publish_log_topics'),
+                "disable_sim_time_clock": LaunchConfiguration('disable_sim_time_clock'),
             }]
     )
 
@@ -75,6 +82,7 @@ def generate_launch_description():
         publish_tf_odom2baselink_arg,
         force_publish_vehicle_namespace_arg,
         publish_log_topics_arg,
+        disable_sim_time_clock_arg,
         use_rviz_arg,
         rviz_config_file_arg,
         mvsim_node,

--- a/mvsim_node_src/include/mvsim/mvsim_node_core.h
+++ b/mvsim_node_src/include/mvsim/mvsim_node_core.h
@@ -190,6 +190,12 @@ class MVSimNode
 	/// vehicle at every simulation timestep. Disabled by default.
 	bool publish_log_topics_ = false;
 
+	/// Default=false. If true, do NOT use mvsim's internal simulation clock:
+	/// the "/clock" topic is not published, and all header stamps (including
+	/// sensor observations) use wall-clock time instead, as done before
+	/// simulation time support was added.
+	bool disable_sim_time_clock_ = false;
+
    protected:
 #if defined(MVSIM_HAS_ZMQ) && defined(MVSIM_HAS_PROTOBUF)
 	mvsim_node::shared_ptr<mvsim::Server> mvsim_server_;
@@ -369,6 +375,11 @@ class MVSimNode
 
 	ros_Time myNow() const;
 	double myNowSec() const;
+
+	/// Stamp to use for a sensor observation: the observation's own
+	/// simulation timestamp, unless disable_sim_time_clock_ is set, in which
+	/// case myNow() (wall-clock) is used instead.
+	ros_Time myObsStamp(const mrpt::system::TTimeStamp& obsTimestamp) const;
 
 	mrpt::system::CTimeLogger profiler_{true /*enabled*/, "mvsim_node"};
 

--- a/mvsim_node_src/mvsim_node.cpp
+++ b/mvsim_node_src/mvsim_node.cpp
@@ -149,8 +149,7 @@ MVSimNode::MVSimNode(rclcpp::Node::SharedPtr& n)
 	localn_.param(
 		"force_publish_vehicle_namespace", force_publish_vehicle_namespace_,
 		force_publish_vehicle_namespace_);
-	localn_.param(
-		"disable_sim_time_clock", disable_sim_time_clock_, disable_sim_time_clock_);
+	localn_.param("disable_sim_time_clock", disable_sim_time_clock_, disable_sim_time_clock_);
 
 	// mvsim is the ROS *time source*: it publishes "/clock" and stamps all
 	// outgoing messages with simulation time. The mvsim node itself therefore

--- a/mvsim_node_src/mvsim_node.cpp
+++ b/mvsim_node_src/mvsim_node.cpp
@@ -149,6 +149,8 @@ MVSimNode::MVSimNode(rclcpp::Node::SharedPtr& n)
 	localn_.param(
 		"force_publish_vehicle_namespace", force_publish_vehicle_namespace_,
 		force_publish_vehicle_namespace_);
+	localn_.param(
+		"disable_sim_time_clock", disable_sim_time_clock_, disable_sim_time_clock_);
 
 	// mvsim is the ROS *time source*: it publishes "/clock" and stamps all
 	// outgoing messages with simulation time. The mvsim node itself therefore
@@ -201,6 +203,9 @@ MVSimNode::MVSimNode(rclcpp::Node::SharedPtr& n)
 		"force_publish_vehicle_namespace", force_publish_vehicle_namespace_);
 
 	publish_log_topics_ = n_->declare_parameter<bool>("publish_log_topics", publish_log_topics_);
+
+	disable_sim_time_clock_ =
+		n_->declare_parameter<bool>("disable_sim_time_clock", disable_sim_time_clock_);
 
 	// mvsim is the ROS *time source*: it publishes "/clock" and stamps all
 	// outgoing messages with simulation time. The mvsim node itself therefore
@@ -636,8 +641,9 @@ ros_Time MVSimNode::myNow() const
 	// coherent regardless of the real-time factor or transient CPU load, and
 	// match the "/clock" topic consumed by downstream nodes running with
 	// use_sim_time:=true. Fall back to wall-clock only before the first
-	// simulation step, when no sim timestamp exists yet.
-	if (mvsim_world_ && mvsim_world_->has_simul_timestamp())
+	// simulation step, when no sim timestamp exists yet, or when the user
+	// explicitly opted out via disable_sim_time_clock_.
+	if (!disable_sim_time_clock_ && mvsim_world_ && mvsim_world_->has_simul_timestamp())
 	{
 		return mrpt2ros::toROS(mvsim_world_->get_simul_timestamp());
 	}
@@ -650,7 +656,7 @@ ros_Time MVSimNode::myNow() const
 
 double MVSimNode::myNowSec() const
 {
-	if (mvsim_world_ && mvsim_world_->has_simul_timestamp())
+	if (!disable_sim_time_clock_ && mvsim_world_ && mvsim_world_->has_simul_timestamp())
 	{
 		return mrpt::Clock::toDouble(mvsim_world_->get_simul_timestamp());
 	}
@@ -659,6 +665,20 @@ double MVSimNode::myNowSec() const
 #else
 	return static_cast<double>(clock_->now().nanoseconds()) * 1e-9;
 #endif
+}
+
+ros_Time MVSimNode::myObsStamp(const mrpt::system::TTimeStamp& obsTimestamp) const
+{
+	// Normally, stamp with the observation's own simulation timestamp (set
+	// when the sensor was sampled) so the stamp is unaffected by any latency
+	// in the asynchronous publisher worker thread. When the sim clock is
+	// disabled, fall back to wall-clock time instead, as done before
+	// simulation time support was added.
+	if (disable_sim_time_clock_)
+	{
+		return myNow();
+	}
+	return mrpt2ros::toROS(obsTimestamp);
 }
 
 /** Initialize all pub/subs required for each vehicle, for the specific vehicle
@@ -901,9 +921,10 @@ void MVSimNode::spinNotifyROS()
 	}
 	// Publish "/clock" so downstream nodes can run with use_sim_time:=true.
 	// mvsim is the simulation time authority; all header stamps below use the
-	// same simulation time base (see myNow()).
+	// same simulation time base (see myNow()). Skipped entirely when
+	// disable_sim_time_clock_ is set, restoring pre-sim-clock behavior.
 	// ----------------------------------------------------------------
-	if (pub_clock_ && mvsim_world_->has_simul_timestamp())
+	if (!disable_sim_time_clock_ && pub_clock_ && mvsim_world_->has_simul_timestamp())
 	{
 		Msg_Clock clockMsg;
 		clockMsg.clock = mrpt2ros::toROS(mvsim_world_->get_simul_timestamp());
@@ -1240,8 +1261,8 @@ void MVSimNode::internalOn(
 
 	// Stamp with the observation's own simulation timestamp (set when the
 	// sensor was sampled), not "now", so the stamp is unaffected by any latency
-	// in the asynchronous publisher worker thread.
-	const auto obsStamp = mrpt2ros::toROS(obs.timestamp);
+	// in the asynchronous publisher worker thread (see myObsStamp()).
+	const auto obsStamp = myObsStamp(obs.timestamp);
 
 	// Send TF:
 	mrpt::poses::CPose3D sensorPose = obs.sensorPose;
@@ -1292,7 +1313,7 @@ void MVSimNode::internalOn(const mvsim::VehicleBase& veh, const mrpt::obs::CObse
 
 	// Stamp with the observation's own simulation timestamp (see note in the
 	// 2D LiDAR handler).
-	const auto obsStamp = mrpt2ros::toROS(obs.timestamp);
+	const auto obsStamp = myObsStamp(obs.timestamp);
 
 	// Send TF:
 	mrpt::poses::CPose3D sensorPose = obs.sensorPose;
@@ -1349,7 +1370,7 @@ void MVSimNode::internalOn(const mvsim::VehicleBase& veh, const mrpt::obs::CObse
 
 	// Stamp with the observation's own simulation timestamp (see note in the
 	// 2D LiDAR handler).
-	const auto obsStamp = mrpt2ros::toROS(obs.timestamp);
+	const auto obsStamp = myObsStamp(obs.timestamp);
 
 	// Send TF:
 	mrpt::poses::CPose3D sensorPose = obs.sensorPose;
@@ -1508,7 +1529,7 @@ void MVSimNode::internalOn(const mvsim::VehicleBase& veh, const mrpt::obs::CObse
 
 	// Stamp with the observation's own simulation timestamp (see note in the
 	// 2D LiDAR handler).
-	const auto obsStamp = mrpt2ros::toROS(obs.timestamp);
+	const auto obsStamp = myObsStamp(obs.timestamp);
 
 	// Send TF:
 	mrpt::poses::CPose3D sensorPose;
@@ -1615,7 +1636,7 @@ void MVSimNode::internalOn(
 
 	// Stamp with the observation's own simulation timestamp (see note in the
 	// 2D LiDAR handler).
-	const auto obsStamp = mrpt2ros::toROS(obs.timestamp);
+	const auto obsStamp = myObsStamp(obs.timestamp);
 
 	// ----------------------------------------------------------------
 	// RGB IMAGE
@@ -1795,7 +1816,7 @@ void MVSimNode::internalOn(
 
 	// Stamp with the observation's own simulation timestamp (see note in the
 	// 2D LiDAR handler).
-	const auto obsStamp = mrpt2ros::toROS(obs.timestamp);
+	const auto obsStamp = myObsStamp(obs.timestamp);
 
 	// POINTS
 	// --------

--- a/mvsim_node_src/mvsim_node.cpp
+++ b/mvsim_node_src/mvsim_node.cpp
@@ -154,8 +154,10 @@ MVSimNode::MVSimNode(rclcpp::Node::SharedPtr& n)
 	// mvsim is the ROS *time source*: it publishes "/clock" and stamps all
 	// outgoing messages with simulation time. The mvsim node itself therefore
 	// normally runs with use_sim_time:=false (it drives the clock); it is the
-	// downstream nodes that should set use_sim_time:=true.
-	if (true == n_.param("use_sim_time", false))
+	// downstream nodes that should set use_sim_time:=true. This does not apply
+	// when disable_sim_time_clock_ is set, since the node no longer drives the
+	// clock in that case.
+	if (!disable_sim_time_clock_ && true == n_.param("use_sim_time", false))
 	{
 		ROS_WARN(
 			"use_sim_time=true was set on the mvsim node itself. mvsim is the "
@@ -209,11 +211,13 @@ MVSimNode::MVSimNode(rclcpp::Node::SharedPtr& n)
 	// mvsim is the ROS *time source*: it publishes "/clock" and stamps all
 	// outgoing messages with simulation time. The mvsim node itself therefore
 	// normally runs with use_sim_time:=false (it drives the clock); it is the
-	// downstream nodes that should set use_sim_time:=true.
+	// downstream nodes that should set use_sim_time:=true. This does not apply
+	// when disable_sim_time_clock_ is set, since the node no longer drives the
+	// clock in that case.
 	{
 		bool use_sim_time = false;
 		n_->get_parameter_or("use_sim_time", use_sim_time, false);
-		if (use_sim_time)
+		if (!disable_sim_time_clock_ && use_sim_time)
 		{
 			RCLCPP_WARN(
 				n_->get_logger(),
@@ -400,19 +404,7 @@ void MVSimNode::spin()
 	}
 
 	// Simulate:
-	const double t_cpu_0 = realtime_tictac_.Tac();
 	mvsim_world_->run_simulation(incr_time);
-	const double sim_cpu = realtime_tictac_.Tac() - t_cpu_0;
-
-	// Instrumentation: warn (throttled) when a single simulation call itself
-	// took longer in wall time than the sim time it advanced -- i.e. this spin
-	// ran slower than real time, the root symptom of the burst stalls above.
-	if (sim_cpu > incr_time && incr_time >= mvsim_world_->get_simul_timestep())
-	{
-		ROS12_WARN_THROTTLE(
-			2000, "run_simulation() took %.3f s CPU to advance %.3f s of sim time.", sim_cpu,
-			incr_time);
-	}
 
 	// t_old_simul = world.get_simul_time();
 	t_old_ = t_new;


### PR DESCRIPTION
## Summary
- Adds a `disable_sim_time_clock` ROS parameter (default: `false`) and matching launch argument (`launch_world.launch` / `launch_world.launch.py`).
- When set to `true`, `mvsim_node` stops publishing `/clock` and stamps all messages (odom, ground-truth, TF, and all sensor observations) with wall-clock time instead of simulation time, restoring the behavior from before the simulation-clock feature (#108) for users who rely on it.
- Docs (`docs/mvsim_node.rst`, `docs/vehicles.rst`) and `agents.md` updated accordingly.

## Test plan
- [x] `colcon build --packages-select mvsim` succeeds
- [x] Verified the new parameter name is compiled into the resulting `mvsim_node` binary
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `disable_sim_time_clock` launch argument and ROS 2 parameter, disabled by default.
  * When enabled, the simulator stops publishing `/clock` and uses wall-clock timestamps for messages, sensor observations, and transforms.
  * Added support across ROS 1 and ROS 2 launch configurations.

* **Documentation**
  * Updated simulation-time guidance and launch examples to describe the new option and its previous-behavior compatibility mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->