### PR TITLE
fix(ros): populate twist in /odom topic

### DIFF
--- a/mvsim_node_src/mvsim_node.cpp
+++ b/mvsim_node_src/mvsim_node.cpp
@@ -1043,6 +1043,14 @@ void MVSimNode::spinNotifyROS()
 					Msg_Odometry odoMsg;
 					odoMsg.pose.pose = mrpt2ros::toROS_Pose(veh_odom_pose);
 
+					// twist is given in the child_frame_id (base_link) frame, as
+					// reconstructed from wheels spinning velocities and geometry:
+					const auto veh_odo_vel = veh->getVelocityLocalOdoEstimate();
+					odoMsg.twist.twist.linear.x = veh_odo_vel.vx;
+					odoMsg.twist.twist.linear.y = veh_odo_vel.vy;
+					odoMsg.twist.twist.linear.z = 0;
+					odoMsg.twist.twist.angular.z = veh_odo_vel.omega;
+
 					// first, we'll populate the header for the odometry msg
 					odoMsg.header.stamp = myNow();
 					odoMsg.header.frame_id = "odom";


### PR DESCRIPTION
## Summary
- The `/<VEH>/odom` `nav_msgs/Odometry` topic only populated `pose`, leaving `twist` all zeros.
- `twist` is now filled from `VehicleBase::getVelocityLocalOdoEstimate()` (the wheel-based odometry velocity estimate), expressed in the `child_frame_id` (`base_link`) frame, consistent with the `nav_msgs/Odometry` convention.

## Test plan
- [x] `colcon build --packages-select mvsim` succeeds.
- [ ] Manually verify `/<VEH>/odom` now carries nonzero `twist.twist.linear`/`angular` while a vehicle is moving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved published odometry data by using the vehicle’s wheel-based velocity estimates.
  * Odometry messages now report more accurate linear and rotational motion values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->